### PR TITLE
add ffrn-change-autoupdater-branch-eoldevices to EOL Targets

### DIFF
--- a/contrib/genpkglist.py
+++ b/contrib/genpkglist.py
@@ -174,9 +174,18 @@ PKGS_TLS = PackageList('TLS', [
 ])
 pkglists.append(PKGS_TLS)
 
+PKGS_EOL = PackageList('EOL', [
+    'ffrn-change-autoupdater-branch-eoldevices'
+])
+pkglists.append(PKGS_EOL)
+
 #
 # package assignment
 #
+
+for target in ['ar71xx-tiny', 'ramips-rt305x']:
+    targets.get(target). \
+        add_pkglist(PKGS_EOL)
 
 targets.get('ar71xx-generic'). \
     add_pkglist(PKGS_USB). \

--- a/modules
+++ b/modules
@@ -1,4 +1,7 @@
-GLUON_SITE_FEEDS='community'
+GLUON_SITE_FEEDS='ffrn community'
+
+PACKAGES_FFRN_REPO=https://github.com/Freifunk-Rhein-Neckar/ffrn-packages.git
+PACKAGES_FFRN_COMMIT=e4c1738ad6e99491596d206f18d828ec7286b729
 
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
 PACKAGES_COMMUNITY_COMMIT=1d7e81b3ebda8fa4896d55c79dff7051e8c0dde4

--- a/site.mk
+++ b/site.mk
@@ -180,6 +180,12 @@ EXCLUDE_TLS := \
     -ca-bundle \
     -libustream-openssl
 
+INCLUDE_EOL := \
+    ffrn-change-autoupdater-branch-eoldevices
+
+EXCLUDE_EOL := \
+    -ffrn-change-autoupdater-branch-eoldevices
+
 ifeq ($(GLUON_TARGET),ar71xx-generic)
     GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
 
@@ -244,8 +250,10 @@ ifeq ($(GLUON_TARGET),ar71xx-nand)
 
 endif
 
-# no pkglists for target ar71xx-tiny
+ifeq ($(GLUON_TARGET),ar71xx-tiny)
+    GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
 
+endif
 
 ifeq ($(GLUON_TARGET),ath79-generic)
     GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
@@ -334,8 +342,10 @@ ifeq ($(GLUON_TARGET),ramips-mt76x8)
     GLUON_tp-link-tl-wr841n-v13_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
 endif
 
-# no pkglists for target ramips-rt305x
+ifeq ($(GLUON_TARGET),ramips-rt305x)
+    GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
 
+endif
 
 ifeq ($(GLUON_TARGET),sunxi-cortexa7)
     GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)


### PR DESCRIPTION
This package will set the autoupdater branch of EOL Nodes in the `nightly` and `experimental` branch to `beta`.

`experimental` and `nightly` firmware images won't be available for EOL Devices.