### PR TITLE
site.conf: add two more time servers

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -31,7 +31,7 @@
 
     -- List of NTP servers in your community.
     -- Must be reachable using IPv6!
-    ntp_servers = {'ntp.ffrn.de', '0.freifunk.pool.ntp.org', 'de.pool.ntp.org'},
+    ntp_servers = {'ntp.ffrn.de', '2.freifunk.pool.ntp.org', '2.de.pool.ntp.org'},
 
     -- Package Manager configuration to allow kernel module install
     opkg = {

--- a/site.conf
+++ b/site.conf
@@ -31,7 +31,7 @@
 
     -- List of NTP servers in your community.
     -- Must be reachable using IPv6!
-    ntp_servers = {'ntp.ffrn.de'},
+    ntp_servers = {'ntp.ffrn.de', '0.freifunk.pool.ntp.org', 'de.pool.ntp.org'},
 
     -- Package Manager configuration to allow kernel module install
     opkg = {


### PR DESCRIPTION
This makes NTP more robust, so a node can get the
current time even if all servers from ntp.ffrn.de
are down.

Signed-off-by: Stefan Weil <sw@weilnetz.de>