### PR TITLE
build-info: update Gluon to 2024-03-06

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "8b30e19b03df22548ca1a76d7d0862393a2e0a6b"
+        "commit": "f3cc781b150f62efcd5081c81aba36d96f1e34ac"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 8b30e19b to f3cc781b.

~~~
f3cc781b Merge pull request #3215 from herbetom/master-updates
ea5ebd9c mac80211: add AQL support for broadcast packets (#3208)
0bbe55ca gluon-ebtables-limit-arp: stop for autoupdater (#3162)
c905ea50 build(deps): bump docker/metadata-action from 5.4.0 to 5.5.1 (#3179)
575a67b3 build(deps): bump korthout/backport-action from 2.1.1 to 2.4.1 (#3177)
981998e2 github: bump paths-filter version (#3180)
3d182a26 modules: update packages
a39d4c93 modules: update openwrt
b64ebad0 ath79-generic: dir-825-b1 drop class tiny (#3210)
2d250b2c Merge pull request #3201 from neocturne/selinux-container
a74de410 build(deps): bump docker/login-action (#3209)
fc424332 Merge pull request #3187 from Djfe/drop-vdsl-packages
e5593d52 ipq40xx-generic: remove all dsl related packages
b287e6f3 lantiq-xrx200: remove obsolete dsl-app again
9ccd353e scripts/container.sh: fix rootless Podman on systems with SELinux
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>
