### PR TITLE
autoupdater: nightly: add GitHub Actions key

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -212,6 +212,7 @@
                 mirrors = {'http://fw.gluon.ffrn.de/nightly/sysupgrade'},
                 good_signatures = 1,
                 pubkeys = {
+                    'ff49b7abc9d2caab57bc5c88fb8cc3b5c5b0eb5312b7cc326a18cc811305592a', -- github-actions-ci
                     'e191158c837941158d827e5c6df971bfb01161d5d6f86a366d8a7897feedf9da', -- buildserver
                 },
             },


### PR DESCRIPTION
This enables an highly automated workflow for deploying nightly firmware.

Once tagged the nightly firmware is automatically build, signed, uploaded and linked.

From there on the Nodes will update to the new firmware.

This means after the tag has been pushed there is no further manual intervention necessary.

This has a higher risk of something going bad or some form of attack.

Hoewer, for nightly the risk seems low enough.

We've always advertised nightly as kinda high risk:

"Absolut ungetestet, automatisch generiert. Nur für absolute Experten."