### PR TITLE
modules: update community repo hash

### DIFF
--- a/modules
+++ b/modules
@@ -4,4 +4,4 @@ PACKAGES_FFRN_REPO=https://github.com/Freifunk-Rhein-Neckar/ffrn-packages.git
 PACKAGES_FFRN_COMMIT=b50c8ff1616b80dc0180adbee0b578c97ae4d0b6
 
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
-PACKAGES_COMMUNITY_COMMIT=b6ab63ebc58bcb428a733026209cc491df10bc3a
+PACKAGES_COMMUNITY_COMMIT=df6e490bc0f7ea5228a7f39cbd0a08e9ec804578


### PR DESCRIPTION
```
df6e490 ffda-ssh-manager: fix handling of default groups
33736f3 ffda-ssh-manager: read defaults from defaults and not default
53a827b ffmuc-mesh-vpn-wireguard: remove more nesting
ca51b60 ffmuc-mesh-vpn-wireguard: warn on invalid mesh_vpn
c82e17b ffmuc-mesh-vpn-wireguard: remove unused limit var
8519587 ffmuc-mesh-vpn-wireguard: remove netfid migration
b44d569 ffmuc-mesh-vpn-wireguard: check for valid privkey
2aa7793 ffmuc-mesh-vpn-wireguard: add check_site script
d9d418f ffmuc-mesh-vpn-wireguard: fix site example
e765b5d ffmuc-mesh-vpn-wireguard-vxlan: delete gluon save
33bfda1 ffgraz-config-mode-at-runtime: fix depends on ffgraz-web-model
23b669c ffgraz-config-mode-theme-funkfeuer: fix typos
e30877c ffac-weeklyreboot: fix typos
d021daf ffmuc-mesh-vpn-wireguard-vxlan: add preload func
dc0d196 ffmuc-mesh-vpn-wireguard-vxlan: fix IPv6 regex
5ac2ac9 ffmuc-mesh-vpn-wireguard-vxlan: Fix wrong context for ntp-server update (#92)
98459e2 remove shellcheck workarounds for busybox sh
d66fc80 ci: update action-shellcheck to v1.20.0
cd3f71e [ffmuc-meh-vpn-wireguard ]Don't exit this causes harm
```