### PR TITLE
build-info: update Gluon to 2024-04-09

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "master",
-        "commit": "5388eb1542d280cafb5d0662a41ba63a85e88f95"
+        "commit": "3c88e4c6ec2f8eec3a0e2a19ea1763f104aec025"
     },
     "container": {
         "version": "master"


### PR DESCRIPTION
Update Gluon from 5388eb15 to 3c88e4c6.

~~~
3c88e4c6 kirkwood: add Linksys E4200 v2 (Viper) Router (#3240)
9614702e build(deps): bump docker/build-push-action from 5.1.0 to 5.3.0 (#3243)
cf2b0f26 build(deps): bump docker/login-action (#3242)
0f390701 build(deps): bump korthout/backport-action from 2.4.1 to 2.5.0 (#3241)
c09bc140 github: add action for OpenWrt base update (#3235)
c468f68f Merge pull request #3238 from neocturne/wifi-cleanup
1a372fbe gluon-web-wifi-config: remove unnecessary uci:get_all() call
afc69e9d gluon-core: lua: wireless: simplify table index lookup in get_wlan_mac_from_driver()
28951a00 Merge pull request #3223 from neocturne/find_phy-iwinfo
5d5b8f01 mac80211: update broadcast AQL patch (#3237)
29e281f7 gluon-core: lua: wireless: use libiwinfo-lua for find_phy()
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de> 