### PR TITLE
build-info: update Gluon to 2024-07-28

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "d9cfa194c131452bc4f927076f35a8217dc2a483"
+        "commit": "23ff99be06822ca5e62b012bafafb271905c9d9d"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from d9cfa194 to 23ff99be.

~~~
23ff99be Merge pull request #3312 from grische/fix/ports-on-7520-v2
6f6c300e Merge pull request #3324 from blocktrron/upstream-main-updates
05a40de6 modules: update routing
fc96dcf9 modules: update packages
97ede66b modules: update openwrt
e3139b5b scripts: enable checks for unassigned uppercase (#3302)
93b600a9 Merge pull request #3301 from grische/read-feeds-dynamically-update-modules
f7d41c50 Merge pull request #3303 from grische/remove-scripts-wide-shellcheck-excludes
e9acd522  scripts: add --tags to git describe in getversion.sh to include lightweighted tags (#3310)
27fe1ed4 gluon-core: migrate lan role of single port config
be4213de fritzbox-7530: utilize lan1 as wan, others as lan With the switch to DSA on this board, we can now utilize the ports better, by splitting them according to their usage
d7ed2dfc Merge pull request #3317 from blocktrron/upstream-main-updates
2b99a849 modules: update packages
b463adb1 modules: update openwrt
5a854853 gluon-web-cellular: add auth option to GUI (#3307)
dc51f3d3 Add documentation for evaluation of mesh-vpn protocols (#3267)
b6f7e4bc scripts: module-check: replace eval with indirection
cf0d2ced scripts: update: replace evals with indirection
deae3d10 scripts: remove scripts-wide shellcheck excludes
2c9d982e scripts: update-modules: fix SC2086
92d4631f scripts: update-modules: read feeds from modules
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>