### PR TITLE
add ffda-node-whisperer

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -21,6 +21,7 @@ features({
 packages({
 	'iwinfo',
 	'respondd-module-airtime',
+	'ffda-node-whisperer',
 })
 
 -- Packages and features for devices which are not flagged as tiny

--- a/modules
+++ b/modules
@@ -4,4 +4,4 @@ PACKAGES_FFRN_REPO=https://github.com/Freifunk-Rhein-Neckar/ffrn-packages.git
 PACKAGES_FFRN_COMMIT=b50c8ff1616b80dc0180adbee0b578c97ae4d0b6
 
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
-PACKAGES_COMMUNITY_COMMIT=df6e490bc0f7ea5228a7f39cbd0a08e9ec804578
+PACKAGES_COMMUNITY_COMMIT=39a38b6f3b530607fa70114dad80434457ecf5e0

--- a/site.conf
+++ b/site.conf
@@ -236,4 +236,19 @@
             },
         },
     },
+
+    node_whisperer = {
+        enabled = true,
+        information = {
+            'hostname',
+            'node_id',
+            'uptime',
+            'site_code',
+            'domain',
+            'system_load',
+            'firmware_version',
+            'batman_adv',
+        },
+    },
+
 }


### PR DESCRIPTION
This package adds debug info to wifi beacons send out by the node. There is an Android App to view them: https://play.google.com/store/apps/details?id=net.freifunk.darmstadt.nodewhisperer