### PR TITLE
build-info: update Gluon to 2024-09-27

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "603a08af3133ca96de2beafce1b9fe3383446b67"
+        "commit": "c0cbcde8f3f3e73e11bcbdfbc72b7c244645424a"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 603a08af to c0cbcde8.

~~~
c0cbcde8 Merge pull request #3342 from blocktrron/upstream-main-updates
fbe05c91 modules: update packages
e0476386 modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>