### PR TITLE
 [v2023.2.x] build-info: update Gluon to 2024-10-03

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "ec72498a44c66a512ceeb45d89cf9ea8f4e5eda8"
+        "commit": "d2a9cc369a32dd1c1b5ffb9ac7a452d78457043d"
     },
     "container": {
         "version": "v2023.2.3"


### PR DESCRIPTION
Update Gluon from ec72498a to d2a9cc36.

~~~
d2a9cc36 Merge pull request #3345 from herbetom/v2023.2.4-release-notes
40f612a5 Merge pull request #3343 from blocktrron/v2023.2.x-updates
934d2c9c docs readme: Gluon v2023.2.4
3f6b43db docs: add v2023.2.4 release notes
535f4283 modules: update packages
ffe9cf85 modules: update openwrt
8d04b5e4 Merge pull request #3341 from herbetom/v2023.2.x-updates
fd51363c modules: update routing
918025b6 modules: update packages
5caa67dd modules: update openwrt
bd5c28e1 docs: update python3-distutils package name (#3326)
1d8bce0a Merge pull request #3325 from blocktrron/v2023.2.x-updates
65322698 modules: update routing
68866210 modules: update packages
87d81f01 modules: update openwrt
05b36ba7 Merge pull request #3318 from blocktrron/v2023.2.x-updates
9ca21220 modules: update packages
1f8d3acc modules: update openwrt
1a5d69ae Merge pull request #3314 from blocktrron/2302-backports-11072024
c82206c7 ath79-generic: add support for Sophos AP15 (#3126)
f4736922 Merge pull request #3313 from blocktrron/v2023.2.x-updates
a0ff929b gluon-core: fix swconfig detection in ethernet module (#3309)
bdee1140 ramips-mt7620: add support for Netgear EX6130 (#3304)
61ee9227 ramips-mt7621: add support for Xiaomi Mi Router 4a Gigabit Edition v2 (#3293)
fb98bc72 ramips-mt76x8: add TP-Link RE200 v4 (#3297)
8a2fd610 modules: update packages
bfbd49ff modules: update openwrt
f0edc3ec Merge pull request #3284 from blocktrron/v2023.2.x-updates
d06f4cab modules: update packages
8c74d7af modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>
