### PR TITLE
build-info: update Gluon to 2024-10-23

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "c0cbcde8f3f3e73e11bcbdfbc72b7c244645424a"
+        "commit": "19cb769b1114446738159f1e493389b66caf2dbf"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from c0cbcde8 to 19cb769b.

~~~
19cb769b Merge pull request #3353 from neocturne/kirkwood-updates
5ed07dc7 kirkwood-generic: add Linksys EA4500
b03393b2 kirkwood-generic: update reason for BROKEN
31933ff1 Merge pull request #3351 from neocturne/main-updates
f0f50aff modules: update packages
f0d5a821 modules: update openwrt
e6bba9fc Revert "tools flex: disable parallel build (#3169)" (#3350)
145ebf06 Merge pull request #3327 from freifunk-gluon/dependabot/pip/docs/sphinx-8.0.2
ebdd3941 docs: conf.py: update deprecated source_suffix configuration
fa5fbdcb docs: requirements.txt: update to Sphinx 8.0.2 and sphinx-rtd-theme 3.0.0
61ec97e8 Merge pull request #3348 from blocktrron/v2023.2.4-main
8a2baf86 docs readme: Gluon v2023.2.4
91d82e17 docs: add v2023.2.4 release notes
7da85f60 Merge pull request #3346 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.9.0
5c5ede37 build(deps): bump docker/build-push-action from 6.7.0 to 6.9.0
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>