### PR TITLE
build-info: update Gluon to 2024-11-05

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "19cb769b1114446738159f1e493389b66caf2dbf"
+        "commit": "7cc3ebddd7ea32ae14167389535cbc7d1df95d8e"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 19cb769b to 7cc3ebdd.

~~~
7cc3ebdd ipq806x-generic: add Ubiquiti UniFi AC HD (#3361)
d3813362 generic: add gluon grub title (#3366)
a836ae7a ramips-mt7621: add Ubiquiti UniFi nanoHD (#3362)
873e5f7b docs readme: update hackint webchat URL (#3360)
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>