### PR TITLE
github: build-gluon: cancel obsolete in progress workflows for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,12 @@ on:
         description: 'Targets to build (space separated)'
         required: false
 
+concurrency:
+  # yamllint disable rule:line-length
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ github.event.pull_request.number || github.run_id }}
+  # yamllint enable rule:line-length
+  cancel-in-progress: true
+
 jobs:
   build-meta:
     outputs:


### PR DESCRIPTION
PR workflows don't need to continue if new commits have been commited.

Based on: https://github.com/freifunk-gluon/gluon/commit/1523a2f4deb566004ac41e369209ec015fbfaf79