### PR TITLE
build-info: update Gluon to 2025-03-09

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "7cc3ebddd7ea32ae14167389535cbc7d1df95d8e"
+        "commit": "cf9f0f92d8f74f5564732787e1786cf8c9908d0f"
     },
     "container": {
         "version": "main"

--- a/.github/free-runner-space.sh
+++ b/.github/free-runner-space.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# For a List of pre-installed packages on the runner image see
+# https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images
+
+echo "Disk space before cleanup"
+df -h
+
+# Remove packages not required to run the Gluon build CI
+sudo apt-get -y remove \
+	dotnet-* \
+	firefox \
+	google-chrome-stable \
+	kubectl \
+	microsoft-edge-stable \
+	temurin-*-jdk
+
+# Remove Android SDK tools
+sudo rm -rf /usr/local/lib/android
+
+echo "Disk space after cleanup"
+df -h

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,9 @@ jobs:
       - name: Print meminfo
         run: cat /proc/meminfo
 
+      - name: Remove non-required software
+        run: bash .github/free-runner-space.sh
+
       - name: Download prepared OpenWrt
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Update Gluon from 7cc3ebdd to cf9f0f92.

~~~
cf9f0f92 Merge pull request #3436 from blocktrron/mt7915-20250113-restart
55d654ff mediatek-filogic: add support for OpenWRT One (#3446)
1feed04d actions: remove non-required packages (#3448)
37886a4c Merge pull request #3447 from blocktrron/upstream-main-updates
2f9461df openwrt: remove mt76 patch
937d25be build: use host LLVM toolchain
8d50f440 Merge pull request #3444 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.2.0
ace6ebcd Merge pull request #3443 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.7.0
dcf67010 Merge pull request #3442 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.15.0
f42266d3 contrib docker: sort package-list
c98454eb modules: update routing
e3120771 modules: update packages
ad1bea9c modules: update openwrt
5f77bba0 build(deps): bump korthout/backport-action from 3.1.0 to 3.2.0
7a98065d build(deps): bump docker/metadata-action from 5.6.1 to 5.7.0
a48d30d8 build(deps): bump docker/build-push-action from 6.13.0 to 6.15.0
49079cfb Merge pull request #3427 from ffac/rssi_for_5ghz
56f9f391 Merge pull request #3437 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.13.0
94a7eb1b mt76: import MT7915 recovery fixes
ae807135 build(deps): bump docker/build-push-action from 6.10.0 to 6.13.0
cd074cc9 Merge pull request #3434 from ffac/update-openwrt-main
7e619101 Merge pull request #3432 from ffac/tplink_ax23
3035005d modules: update packages
02cf7d43 modules: update openwrt
5b4e1091 ramips-mt7621: add tp-link ax23
ff58f65a ramips-mt7621: add support netgear eax12 (#3433)
ad321f50 Merge pull request #3429 from ffac/update-openwrt-main
a4c78821 modules: update packages
368ee823 modules: update openwrt
4e2188a7 gluon-core: set 5GHz rssi leds to mesh1 connectivity
3c04d32d Merge pull request #3428 from blocktrron/upstream-main-updates
8f853668 armsr: change image name
2cf299d8 modules: update routing
e2b5bca6 modules: update packages
8137470e modules: update openwrt
ab1c3118 net: mac80211: force backwards compatible basic rates (#3419)
24a5fd4d Merge pull request #3421 from ffac/update-openwrt-main
56ad0ae9 Merge pull request #3422 from s-2/m30
b3130ff4 docs: move D-Link M30, M60 to mediatek-filogic
c99f9c04 modules: update packages
e9098728 modules: update openwrt
791e39f4 Merge pull request #3407 from RolandoMagico/M60
0b23f899 mac80211: silence mesh rate mismatch warning (#3416)
9c914db0 mediatek-filogic: Add support for D-Link AQUILA PRO AI M60 A1
a475b191 gluon-private-wifi: rename psk3 to sae
4c7aef6e Merge pull request #3411 from blocktrron/upstream-main-updates
912527ab wifi-scripts: allow per-IF mesh basic rate selection
fb08eabb gluon-core: set basic-rate for mesh interface
06e421ed net: mac80211: always pretend 1 Mbit/s as mesh basic rate
d6e74f00 net: mac80211: override incompatible basic-rates for mesh
ebc4a606 generic: rename SECCOMP config option
f168aca9 modules: update packages
fbe070c4 modules: update openwrt
e5675adc docs: add AP3915i to supported_devices (#3413)
c31c7d75 Merge pull request #3405 from ffac/allow_fb7530_dsl
828ac800 Merge pull request #3396 from ffac/ap3915i
d87fadb7 ipq40xx-generic: add extreme-networks-ws-ap3915i
e1523af5 Merge pull request #3401 from ffac/update-openwrt-main-1734975929
6b80b580 mediatek-filogic: add Cudy AP3000 Outdoor v1 (#3384)
b5ba291b readd moved xrx200_legacy target
b110494f remove devices which were moved to lantiq-xrx200_legacy
b720d4d0 patches: make refresh-patches
d66cfc0c modules: update packages
9271070c modules: update openwrt
1757fff8 ipq40xx-generic: add working VDSL config for FB7530
4f6de05a Merge pull request #3403 from ffac/silence_airtime_link_metric_get
e594ce2e mac80211: silence warning for missing rate information
717bf99c Merge pull request #3400 from RolandoMagico/D-Link_M30
1e50f2e4 mediatek-filogic: Add support for D-Link AQUILA PRO AI M30 A1
fc25b494 Merge pull request #3394 from grische/drop-python3-distutils
246489be Merge pull request #3399 from ffac/update-openwrt-main-1734601207
f2aeb462 ath79: Add support for Sophos AP15C (#3385)
def60f86 modules: update routing
8998470d modules: update packages
c5700b64 modules: update openwrt
3af76af4 Merge pull request #3387 from herbetom/main-updates
3654f83a libgluonutil: add missing libgen import (#3395)
51719c69 Dockerfile: drop dependency on python3-distutils
879e4501 modules: update routing
36d907fe modules: update packages
a625ae4f modules: update openwrt
b180fc28 Merge pull request #3363 from freifunk-gluon/dependabot/pip/docs/sphinx-8.1.3
608a6658 Merge pull request #3382 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.6.1
80a16ba0 Merge pull request #3383 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.10.0
d16fe2ae docs: user/supported_devices: remove unreferenced footnote
9dd90850 build(deps): bump sphinx from 8.0.2 to 8.1.3 in /docs
92845384 Merge pull request #3381 from freifunk-gluon/dependabot/pip/docs/sphinx-rtd-theme-3.0.2
adbb283e Merge pull request #3380 from grische/add-nanopi-r3s-support
f18b1d9f Merge pull request #3372 from T-X/pr-openwrt-24.10-bridge-wakeupcall
b4b3cb29 Merge pull request #3371 from T-X/pr-openwrt-24.10-batman-adv-noflood
aa39a94e add support for NanoPi R3S
2b129f68 kernel: bridge: readding MLD wakeup call feature
bfff4233 Revert "routing: remove noflood"
f18a350a Merge pull request #3370 from freifunk-gluon/openwrt-24.10
77a83ce1 generic: enable kernel namespace support
4bbe5550 generic: fix ramips-mt76x8 compile
b7481fd0 modules: switch to OpenWrt 24.10
3688bf2e scripts: remove temporary output directory
224d0aa7 ramips-mt7621: remove Edgerouter X
35b70fce mediatek-mt7622: remove Xiaomi Redmi AX6S
702211ac routing: remove noflood
b1cdcc87 docker: add missing dependencies
7c0b77b3 build(deps): bump docker/build-push-action from 6.9.0 to 6.10.0
43861fa6 build(deps): bump docker/metadata-action from 5.5.1 to 5.6.1
b31f045d build(deps): bump sphinx-rtd-theme from 3.0.0 to 3.0.2 in /docs
f3cae19c Merge pull request #3378 from blocktrron/upstream-main-updates
bf33ce4e modules: update packages
87ce9825 modules: update openwrt
33f6538c Merge pull request #3374 from blocktrron/upstream-main-updates
4b0d5f50 modules: update routing
edd07a55 modules: update packages
dd907e68 modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>