### PR TITLE
site.mk: bump FFRN_SITE_VERSION to 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you have any questions, please feel welcome to contact the community: [Kontak
 * `main`:
     * matches Gluons `main` branch
     * published as nightly
-    * firmware version: 2.2.x-yyyymmdd
+    * firmware version: 2.3.x-yyyymmdd
 * `v2023.2.x`:
     * matches Gluon `v2023.2.x` branch
     * firmware version: v2.2.x

--- a/site.mk
+++ b/site.mk
@@ -7,7 +7,7 @@
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
-FFRN_SITE_VERSION := 2.2
+FFRN_SITE_VERSION := 2.3
 
 DEFAULT_GLUON_RELEASE := $(FFRN_SITE_VERSION).x-$(shell date '+%Y%m%d')
 DEFAULT_GLUON_PRIORITY := 0


### PR DESCRIPTION
Bump nightly version due to gluon now beeing based on openwrt-24.10.