### PR TITLE
build-info: update Gluon to 2025-03-28

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "28f2ee9a923bd9253ca2663d551e585590da2561"
+        "commit": "1be370b420ac65e66e1aae92a69a7929c5309e28"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 28f2ee9a to 1be370b4.

~~~
1be370b4 Merge pull request #3460 from herbetom/main-updates
c8ef95c7 modules: update packages
b8e5ae9e modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>