### PR TITLE
build-info: update Gluon to 2025-04-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "1be370b420ac65e66e1aae92a69a7929c5309e28"
+        "commit": "974e454469a2c7b9fde9744e7d10994228931960"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 1be370b4 to 974e4544.

~~~
974e4544 Merge pull request #3472 from herbetom/main-updates
091ced3f Merge pull request #3471 from neocturne/lint-initscripts
da89dff8 modules: update packages
b741dc46 modules: update gluon
0da16425 modules: update openwrt
e94775f1 lint: sh: add checking for initscripts
c2d14538 lint: sh: improve shellscript detection
085250c2 treewide: fix or disable lint warnings in initscripts
60734d56 perl: drop patch to disable parallel build (#3470)
892fd149 Merge pull request #3468 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.4.0
c45fc618 build(deps): bump docker/login-action from 3.3.0 to 3.4.0
caba048e Merge pull request #3467 from neocturne/shellcheck2
6cd474b7 Merge pull request #3465 from neocturne/no-keep-opkg-keys
fe91b041 Merge pull request #3463 from neocturne/autoupdater-https
517433e8 Merge pull request #3464 from neocturne/wan-dnsmasq-ujail
092a086d lint: sh: enable previously disabled warnings
604e7e54 treewide: fix previously disabled shellcheck warnings
bd746da4 gluon-mesh-vpn-*: move gluon_wireguard netifd proto to gluon-mesh-vpn-wireguard
f1bd38dc opkg: do not preserve opkg keys on upgrades by default
dc13c17a gluon-wan-dnsmasq: add ujail configuration
4ccb5ccb gluon-wan-dnsmasq: run as dnsmasq user/group
f9c341a3 gluon-wan-dnsmasq: use long option names
715abd7f Merge pull request #3414 from ChristianMiddendorf/main
c800fe7f gluon-autoupdater: add support for HTTPS and protocol-less URLs
877ae95a gluon-tls: add marker file
078006f8 ramips-mt76x8: add support for Xiaomi Mi Router 4A (100M International Edition v2 - R4ACv2)
1de93e1e docs: ramips-mt76x8: add Xiaomi Mi Router 4 model IDs
4b3eb116 Merge pull request #3461 from neocturne/drop-realtek-rtl838x
4e847f7e hardware: remove support for D-Link DGS-1210-10P and realtek-rtl838x target
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>