### PR TITLE
build-info: update Gluon to 2025-04-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "974e454469a2c7b9fde9744e7d10994228931960"
+        "commit": "c4e8f9febc5b4333fa4ef190a0ef87c46151ce3e"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 974e4544 to c4e8f9fe.

~~~
c4e8f9fe Merge pull request #3474 from neocturne/main-updates
72927cad modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>
