### PR TITLE
build-info: update Gluon to 2025-04-22

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "c4e8f9febc5b4333fa4ef190a0ef87c46151ce3e"
+        "commit": "08ce23fc551fd8ed36b265bbbd484492d3236684"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from c4e8f9fe to 08ce23fc.

~~~
08ce23fc ramips-mt76x8: add support for TP-Link TL-WR902AC v4 (#3491)
84fb35d0 mediatek-filogic: add support for Cudy TR3000 v1 (#3473)
f1349022 Merge pull request #3488 from blocktrron/pr-bugfix-dnsmasq-ex25519-small-flash
5d9532ae Merge pull request #3480 from blocktrron/pr-dsa-conduit
3c0186c6 gluon-core: use single conduit interface for DSA topology
c91c76b2 generic: enable dnsmasq ed25519 keys regardless of target
d8145f83 Merge pull request #3457 from neocturne/shellcheck
377b03b9 Merge pull request #3485 from freifunk-gluon/issue-2081
79dc555b core: remove transitive option from network interfaces
8580bd91 Merge pull request #3477 from neocturne/block-nested-vxlan
fef15507 Merge pull request #3478 from neocturne/remove-node_client_prefix6
090bcda7 gluon-ebtables-filter-multicast: block packets with Gluon VXLAN multicast destination
a4b078d6 gluon-mesh-layer3-common: remove deprecated node_client_prefix6 from site
373e2b8e Merge pull request #3475 from neocturne/main-updates
9f6e4578 modules: update packages
3a15c4e7 modules: update openwrt
e1bb8949 gluon-mesh-vpn-wireguard: fix shellcheck warnings in netifd proto
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>