### PR TITLE
build-info: update Gluon to 2025-05-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "4627d80d69872a93b65ef0c94753d31b6831a431"
+        "commit": "d2a85227ccd32b0e37d88bb711f878c1184d36c2"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 4627d80d to d2a85227.

~~~
d2a85227 Merge pull request #3503 from neocturne/info-i18n
0a858a3a gluon-core: fix German translation for "Switch type"
37bc9415 gluon-core, gluon-web-admin: move translations for gluon-info strings to gluon-core
76561294 Merge pull request #3502 from ffac/improve_docs
4fc56afb docs: gluon-web-network: fix  enumerations
4afdc227 Merge pull request #3496 from herbetom/respondd-taget-info
adcedf15 package/gluon-respondd: add target information
5dc5301a Merge pull request #3495 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.16.0
57e297ef build(deps): bump docker/build-push-action from 6.15.0 to 6.16.0
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>