### PR TITLE
build-info: update Gluon to 2025-05-13

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "d2a85227ccd32b0e37d88bb711f878c1184d36c2"
+        "commit": "a596d37b7b754ff46f81b2ed054f0aa5747b0348"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from d2a85227 to a596d37b.

~~~
a596d37b Merge pull request #3505 from blocktrron/pr-ex400
d614d9aa Merge pull request #3506 from blocktrron/pr-ax52
caf75dd9 ramips-mt7621: add support for Genexis Pulse EX400
364a4bdb mediatek-filogic: add ASUS RT-AX52
91c2bba3 Merge pull request #3504 from blocktrron/upstream-main-updates
15f85a47 modules: update packages
51b37987 modules: update gluon
d9ab6c3a modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>