### PR TITLE
build-info: update Gluon to 2025-05-15

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "a596d37b7b754ff46f81b2ed054f0aa5747b0348"
+        "commit": "d8177d641f55cb8bc3b963427177b6c41081b690"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from a596d37b to d8177d64.

~~~
d8177d64 Merge pull request #3508 from blocktrron/pr-bootcount
0f66e109 Merge pull request #3507 from blocktrron/upstream-main-updates
5c064002 gluon-setup-mode: execute bootcount initscript in setup-mode
067c1a38 modules: update packages
8a0b9040 modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>