### PR TITLE
ci: build: add target job for a required build status check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,6 +292,21 @@ jobs:
             "gluon-gha-data/gluon/output/images/other/*"
             "gluon-gha-data/gluon/output/images/factory/*"
 
+  # target job for required status check of build success
+  build-complete:
+    name: All Targets Build
+    runs-on: ubuntu-22.04
+    needs: [build, build-meta, targets]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Error out if there is a failure
+        if: ${{ needs.build.result != 'success' }}
+        run: |
+          echo "Build Matrix Result: ${{ needs.build.result }}"
+          exit 1
+      - name: All firmware builds succeded
+        run: echo "All firmware builds succeded!"
+
   manifest:
     needs: [build, build-meta, targets]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
It doesn't seem possible to define a matrix as a target for required status checks. So we need to work arround this by a job which is run after our build matrix.

This accomplishes that.

Required Status Checks help us to ensures that PRs with a failed CI action aren't accidentaly meged.

This also enables us to enable the auto merge feature.

Auto Merge should only be enabled on PRs from trusted sources since it isn't automatically disabled if the source branch has been changed.

For example with our "Bump Gluon" it should be fine to use.