### PR TITLE
build-info: update Gluon to 2025-05-27

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "d8177d641f55cb8bc3b963427177b6c41081b690"
+        "commit": "73865b6d35626d01c6056c31bf028ebc0aacd071"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from d8177d64 to 73865b6d.

~~~
73865b6d Merge pull request #3514 from blocktrron/upstream-main-updates
a6135ecb modules: update packages
c9217c43 modules: update openwrt
480fdf57 Merge pull request #3511 from freifunk-gluon/refactor/env-bash
a80f65c1 scripts: Alter shebangs to /usr/bin/env bash
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>