### PR TITLE
[v2023.2.x] build-info: update Gluon to v2023.2.5

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "d2a9cc369a32dd1c1b5ffb9ac7a452d78457043d"
+        "commit": "031a835e4f6658dc6f720ef55635baf4841a7cb6"
     },
     "container": {
         "version": "v2023.2.3"


### PR DESCRIPTION
Update Gluon from d2a9cc36 to 031a835e.

~~~
031a835e Merge pull request #3515 from blocktrron/pr-v2023.2.5-rn
1ec4a686 docs readme: Gluon v2023.2.5
f6541b26 docs: add Gluon v2023.2.5 release notes
a52d3519 Merge pull request #3513 from blocktrron/v2023.2.x-updates
05d2b674 modules: update packages
c3c28740 modules: update openwrt
ea80921a Merge pull request #3509 from blocktrron/pr-ex400-2023.2
c680ce29 ramips-mt7621: add support for Genexis Pulse EX400
8d629bb3 ramips-mt7621: backport Genexis Pulse EX400 to OpenWrt 23.05
285e1814 gluon-setup-mode: execute bootcount initscript in setup-mode
0be35204 Merge pull request #3497 from herbetom/v2023.2.x-backport-respondd-targetinfo
ca8092e9 Merge pull request #3498 from herbetom/v2023.2.x-updates
020fab0e modules: update gluon
f6c3834e modules: update routing
26401438 modules: update packages
932d1cbd modules: update openwrt
ca9dcd5b package/gluon-respondd: add target information
89873668 Merge pull request #3486 from freifunk-gluon/backport-3477-to-v2023.2.x
7303e846 gluon-ebtables-filter-multicast: block packets with Gluon VXLAN multicast destination
89c1ea51 labeler: update "continuous integration" label name (backport of #3152) (#3458)
aadfbad2 Merge pull request #3453 from neocturne/v2023.2.x-sophos-ap15c
b0fd43ab ath79: Add support for Sophos AP15C
5d49a964 Merge pull request #3451 from herbetom/v2023.2.x-updates
153f0b03 docs: user/supported_devices: remove unreferenced footnote
885c0ca8 docs: requirements.txt: update to Sphinx 8.1.3 and sphinx-rtd-theme 3.0.2
c9d482f6 modules: update routing
c93df81f modules: update packages
4013231e modules: update openwrt
e74d3edd Merge pull request #3404 from neocturne/v2023.2.x-doc-fixes
e354114d docs: apply suggestions from code review
7dbd0946 docs: add documentation to gluon-config-mode-geo-location-osm package
63d232ee docs: add picture to configmode page
7c1ef7db docs autoupdater: fix manifest underline
d5868e5a docs status-page: add docs about status-page feature
d2526b11 docs x86: Prefer x86-64 bit (alphanumerical order) Add information about old x86 images
479a00bc docs gluon-tls: add documentation about gluon-tls feature
c9dabef1 docs configmode: add links to specific package docs of config mode
7a4c5cd0 docs: add docs for gluon-web-cellular
3a9dc768 docs: add documentation about gluon-web-network package * document network roles and their effects
45564507 docs: add note about outdoor mode to wlan-configuration
27544897 docs: user/getting_started: fix monospace markup
a3a296eb treewide: Update main branch name (#3282)
3c758121 docs: site: pubkey_privacy works for wireguard (#3254)
744b0622 build(deps): bump sphinx from 7.2.6 to 7.3.7 in /docs (#3249)
0c851862 docs: fix typos
a680e606 docs: fix AVM Recovery Tool url in v2023.1.1 release notes
5482ead9 docs: fix typo in v2023.2 release notes (#3195)
425b12aa targets: docs: Make target files and OEMs more consistent
5648a851 docs: add v2023.1.2 release notes
65f348e2 build(deps): bump sphinx from 7.1.2 to 7.2.6 in /docs (#3133)
534b8807 Merge pull request #3388 from herbetom/v2023.2.x-updates
6f289cf0 libgluonutil: add missing libgen import (#3395) (#3398)
02b8c463 modules: update routing
8c87cabc modules: update packages
94cb0786 modules: update openwrt
01193c8f Merge pull request #3375 from blocktrron/v2023.2.x-updates
84e79360 modules: update routing
1fe668d3 modules: update packages
fcb07c0b modules: update openwrt
979e8db7  scripts: add --tags to git describe in getversion.sh to include lightweighted tags (#3310) (#3359)
831e6696 Merge pull request #3352 from neocturne/v2023.2.x-updates
97edda89 modules: update packages
e3496efb modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>