### PR TITLE
image-customization: don't include SQM on unsupported targets

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -24,6 +24,17 @@ packages({
 	'ffda-node-whisperer',
 })
 
+-- Enable SQM only on targets which have the CPU capabilities
+-- to use CAKE
+if not target('ath79')
+	and not target('ramips')
+	and not target('lantiq')
+	then
+	features({
+		'mesh-vpn-sqm'
+	})
+end
+
 -- Packages and features for devices which are not flagged as tiny
 if not device_class('tiny') then
 	packages({
@@ -31,7 +42,6 @@ if not device_class('tiny') then
 	})
 
 	features({
-		'mesh-vpn-sqm',
 		'tls',
 		'web-cellular',
 		'wireless-encryption-wpa3'


### PR DESCRIPTION
This frees quite a lot of flash space on these targets. As SQM is onkly enabled on devices with sufficient RAM, these devices did not use SQM anyways.

Ref: https://github.com/freifunk-darmstadt/site-ffda/commit/3b1529a2b32ecb40f9311669d96f482983c51304