### PR TITLE
modules: update community repo hash

### DIFF
--- a/modules
+++ b/modules
@@ -4,4 +4,4 @@ PACKAGES_FFRN_REPO=https://github.com/Freifunk-Rhein-Neckar/ffrn-packages.git
 PACKAGES_FFRN_COMMIT=b50c8ff1616b80dc0180adbee0b578c97ae4d0b6
 
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
-PACKAGES_COMMUNITY_COMMIT=39a38b6f3b530607fa70114dad80434457ecf5e0
+PACKAGES_COMMUNITY_COMMIT=4a90cd221e8eba254ffc8dc5addbf3374b830415


### PR DESCRIPTION
View changes: https://github.com/freifunk-gluon/community-packages/compare/39a38b6f3b530607fa70114dad80434457ecf5e0...4a90cd221e8eba254ffc8dc5addbf3374b830415

Changelog:

```
ab52d42 ffbs-mesh-vpn-parker: Let nodeconfig report success even if vpn disabled
4886ab2 ffbs-mesh-vpn-parker: nodeconfig.sh: Report tc limits to config-server
32b27e4 ffbs-mesh-vpn-parker: noderoute.sh: Fix logger shaddowing returncode
8c3c275 ffbs-mesh-vpn-pakrer: nodeconfig.lua: Apply traffic limits
8d3cf92 ffbs-mesh-vpn-pakrer: nodeconfig.lua: Add comments
4bddbe1 ffbs-mesh-vpn-pakrer: Fix nodeconfig.lua exiting due to a nil-value
2e5b30f ffbs-mesh-vpn-parker: depend on simple-tc
519e6eb Adding editorconfig-checker Github action
1493e17 treewide: editorconfig: fix indentation and eof-newlines
6d032f0 treewide: Migrate to SPDX header
57a4f01 editorconfig-checker: adding config file
b56eaa3 editorconfig: sync to version in the official packages repository
aafd6b2 fix bug in ssid-changer introduced in lua rewrite
2735fdc ci: sync linting to the version in gluon-packages
862167e Add .shellcheckrc
b37699a ffbs-mesh-vpn-parker: fix reading persistent_keepalive and typos
7611b92 ffbs-mesh-vpn-parker: Remove all wireguard interfaces on autoupdate
b25e816 add normal logging and only change ssid if it is not already set to offline
f5d26f6 make script backwards compatible for openwrt 23.05
8b2e0ca ffbs-mesh-vpn-parker: fix shell word splitting
8d2d47c ffbs-parker-nextnode: use BuildPackageGluon instead of BuildPackage
4f321ed ffbs-mesh-vpn-parker: silence shellcheck errors due to /etc/rc.common
129fb2e ffbs-mesh-vpn-parker: fix shellcheck errors
b90d68b ffbs-mesh-vpn-parker: remove obsolete copyright copied from example
e57234c ffbs-mesh-vpn-parker: Drop files in /etc/rc.d
382049e ffbs-mesh-vpn-parker: Mark files in gluon/upgrade as executable
0a1beb4 ffbs-mesh-vpn-parker: Rename respondd-dependency
a320cf1 ffbs-mesh-vpn-parker: delete prefix6 firewall rule
b2e19a7 ffbs-mesh-vpn-parker: move parker pubkey to uci
2bc4460 ffbs-mesh-vpn-parker: place ipv4 wan routes into table 1
655959f ffbs-mesh-vpn-parker: configure unreachable routes
748d3e3 ffbs-mesh-vpn-parker: make sure wg-pubkey exists
de9b244 ffbs-mesh-vpn-parker: fix default parker config
46cc67c ffbs-mesh-vpn-parker: check uci for config_server
93415d0 ffbs-parker-nextnode: Change dependency direction to ffbs-parker-nodeconfig
285a6d5 Add ffbs-parker-nextnode
4e85ebf ffac-ssid-changer: reimplement in lua
d655b2b ffbs-collect-debug-info: collect routes for table 1 and policy routing rules
2c09555 ffac-web-dsl: initial package version
b54cbc1 ffac-dsl: initial package
62bdafd ffac-ssid-changer: silence grep if going offline
a94dc26 wireguard-registration: on openwrt24.10 the https check prints to stderr
e8b6ad3 ffbs-parker-respondd: Rename from ffbs-parker-nodeconfig-respondd
f6b8829 ffbs-parker-nodeconfig-respondd: Drop circular dependency
d77cc2d ffbs-mesh-vpn-parker: reduce nesting in noderoute
67e1468 Add ffbs-parker-nodeconfig-respondd
35b7dc7 ffbs-mesh-vpn-parker: Drop legacy route check
b4f01b6 fixes for luacheck
ca674f5 move luasrc around, fix wrong provider folder location
2f4d446 fix duplicate dependency
ca7eea1 make backwards compatible by providing former package name
c8460a6 rename ffbs-parker-nodeconfig to ffbs-mesh-vpn-parker
537609b add parker provider to ffbs-parker-nodeconfig
2f48599 ffbs-parker-nodeconfig: firewall: Allow respondd from all internal addr
f66665d ffbs-parker-nodeconfig: Get NTP server from site
94c4fe6 Add ffbs-parker-nodeconfig
d839133 ffda-node-whisperer: update to latest HEAD
c62acad Add ffbs-wireguard-respondd
8dca97b ffac-autoupdater-wifi-fallback: clarify interface and network, remove old wireless config change, remove unrequired ubus calls and params
7b4e8ad ffac-autoupdater-wifi-fallback: add improvements from tecff
ae79829 ffbs-collect-debug-info: Also run netstat
a6dbaa7 ffbs-debugbathosts: Rename the Gateways-only parameter to --gw-only
37b9fb1 ffbs-debugbathosts: Move lua sources to luasrc/
137a022 fix whitespace
ed24f61 improve some wubis dupsis
f02264a add headers
```