### PR TITLE
[v2023.2.x] build-info: update Gluon to 2025-06-11

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2023.2.x",
-        "commit": "031a835e4f6658dc6f720ef55635baf4841a7cb6"
+        "commit": "082ca522c271cd4161ece7307ebce8cefc33c0f7"
     },
     "container": {
         "version": "v2023.2.3"


### PR DESCRIPTION
Update Gluon from 031a835e to 082ca522.

~~~
082ca522 gluon-setup-mode: ignore capacitive buttons on Pulse EX400 (#3524)
f014c58b Merge pull request #3521 from neocturne/v2023.2.5-typo
33dcb853 docs: releases/v2023.2.5: fix typo
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>