### PR TITLE
build-info: update Gluon to 2025-06-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "73865b6d35626d01c6056c31bf028ebc0aacd071"
+        "commit": "0193319af66457ea92dd7ff7ee0738a3a4295740"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 73865b6d to 0193319a.

~~~
0193319a Merge pull request #3522 from blocktrron/pr-genexis-touch-disable
ed67c780 Merge pull request #3484 from ffac/add_autoupdater_info
193660e2 gluon-core: make clear if mesh-vpn/public vpn key is disabled correctly in gluon-info
1a8257ec gluon-core: add autoupdater info to gluon-info
ed6823b8 gluon-setup-mode: ignore capacitive buttons on Pulse EX400
464fc6d4 Merge pull request #3517 from blocktrron/pr-v2023.2.5-main
f4cb2e2d docs: releases/v2023.2.5: fix typo
840c2c18 Merge pull request #3518 from freifunk-gluon/dependabot/github_actions/docker/build-push-action-6.18.0
41763441 build(deps): bump docker/build-push-action from 6.16.0 to 6.18.0
06bc963a docs readme: Gluon v2023.2.5
8fd5f11b docs: add Gluon v2023.2.5 release notes
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>