### PR TITLE
build-info: update Gluon to 2025-06-21

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "0193319af66457ea92dd7ff7ee0738a3a4295740"
+        "commit": "d7619c6008b8027a212e23908e4c33fa15e792c7"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 0193319a to d7619c60.

~~~
d7619c60 gluon-state-ntpd-check: Add package (#3528)
9794e83b Merge pull request #3097 from blocktrron/openwrt-profile-info
642e6313 ci: seperately store metadata output
367d8e52 ci: check build-output image size
7f14b431 contrib: add script for validating image-size
321cd5b1 build: include size-limits to device-metadata
06273248 build: copy OpenWrt profile JSON
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>