### PR TITLE
build-info: update Gluon to 2025-06-24

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "0193319af66457ea92dd7ff7ee0738a3a4295740"
+        "commit": "e80777b86761419647cd39ced76639af1920494e"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 0193319a to e80777b8.

~~~
e80777b8 Merge pull request #3527 from dg0tm/main
44073921 ramips-mt7621: add back Edgerouter X" (#3533)
c8b1dad3 Merge pull request #3529 from freifunk-gluon/main-updates
000b6e51 modules: update routing
acd7cf9d modules: update packages
bdf0720e modules: update openwrt
d7619c60 gluon-state-ntpd-check: Add package (#3528)
9794e83b Merge pull request #3097 from blocktrron/openwrt-profile-info
642e6313 ci: seperately store metadata output
367d8e52 ci: check build-output image size
7f14b431 contrib: add script for validating image-size
321cd5b1 build: include size-limits to device-metadata
06273248 build: copy OpenWrt profile JSON
dbf3e4d6 gluon-mesh-layer3-common: get rid of substitution count returned by gsub on prefix
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>