### PR TITLE
build-info: update Gluon to 2025-07-03

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "e80777b86761419647cd39ced76639af1920494e"
+        "commit": "ace4f647e9353500f5b884a133bd03ccc8fcab76"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from e80777b8 to ace4f647.

~~~
ace4f647 Merge pull request #3148 from neocturne/image-customization-include
7f583d2a Merge pull request #3542 from freifunk-gluon/refactor/move-ntpd-state-check
1aa95a05 Merge pull request #3510 from s-2/wn573hx3
41d15b3b mediatek-filogic: add Wavlink WL-WN573HX3
e8502ca0 gluon-state-check: Merge with gluon-state-ntpd-check
70b4e729 scripts: image_customization_lib: add include() function
6973d479 scripts: image_customization_lib: reword and add more argument checks
4637c79e docs: user/site: add examples for image customization functions
bb3a6f32 docs: site-example: add trailing commas in image-customization
ecacd5ec Makefile: improve error messages
1ad9a3a9 Merge pull request #3538 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.2.1
31e745d6 build(deps): bump korthout/backport-action from 3.2.0 to 3.2.1
d38f0bd0 Merge pull request #3532 from dg0tm/gluon-l2roamd
feccb9d1 Merge pull request #3530 from freifunk-gluon/docs/unsupported-uci-options
0bd0cf88 docs: Add FAQ sections for setting retention and gluon_preserve
e33e32ef gluon-l3roamd: startup fix
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>