### PR TITLE
build-info: update Gluon to 2025-07-22

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "7b3f7e10197fd8b4672db80dcd5a7eab1044ba43"
+        "commit": "a05a0f8efa0505a4163375dc469930665f6f9865"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 7b3f7e10 to a05a0f8e.

~~~
a05a0f8e Merge pull request #3549 from herbetom/main-updates
8089c0ef modules: update packages
a29f4261 modules: update openwrt
391988d8 Merge pull request #3539 from ffac/mac_generation_by_name
3fb658ec Merge pull request #3547 from freifunk-gluon/feat/rename-gluon-wan
51b6b972 mesh-vpn-core: rename gluon-wan to gluon-wan-dns
99f5903b Merge pull request #3546 from freifunk-gluon/chore/tc-test
bc5af301 mesh-vpn-wireguard: Mark tc test as completed
47f176e9 gluon-core: update get_wlan_mac to use named mac address
8d49d6a4 gluon-core: change interpretation of radio and mac index 1-based to 0-based in get_wlan_mac
8fea4c7c gluon-core: introduce generate_mac_by_name
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>