### PR TITLE
build-info: update Gluon to 2025-09-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "e00940ef53e55098e995b6e0329723077fe1cede"
+        "commit": "f34cf48f0a759e027052a69b007795f73b557e9d"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from e00940ef to f34cf48f.

~~~
f34cf48f gluon-client-bridge: provide owe with its correct wifi mac (#3579)
cce9ccdb Merge pull request #3577 from herbetom/main-updates
076c819a modules: update packages
1bd1eb10 modules: update openwrt
15681ac6 Merge pull request #3570 from freifunk-gluon/feat/configurable-uradvd-parameters-updates
f549310f gluon-radvd: Allow lifetime configuration in site
09893668 Merge pull request #3573 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.3.0
06fd1bb1 Merge pull request #3575 from freifunk-gluon/dependabot/github_actions/actions/checkout-5
b8f932fe Merge pull request #3574 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.8.0
f5f9d91f Merge pull request #3572 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.5.0
750faacb build(deps): bump actions/checkout from 4 to 5
3a26a65a build(deps): bump docker/metadata-action from 5.7.0 to 5.8.0
912826d3 build(deps): bump korthout/backport-action from 3.2.1 to 3.3.0
a0b71e60 build(deps): bump docker/login-action from 3.4.0 to 3.5.0
dcc57872 Merge pull request #3571 from freifunk-gluon/fix/mesh-layer3-common-new-site-library
2c7f0e84 mesh-layer3-common: Omit redundant check
9763474c mesh-layer3-common: fix radvd start with dns.servers, but without next_node.ip config
76f2a3db Merge pull request #3569 from freifunk-gluon/main-updates
8ec28057 gluon-mesh-batman-adv: fix has_default_gw4 (#3567)
ee32cd3c modules: update packages
18c2ce54 modules: update openwrt
2c5a088d Merge pull request #3565 from herbetom/fix-update-modules
60ef31df scripts: update-modules: always request git remote branch head
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>