### PR TITLE
build-info: update Gluon to 2025-10-12

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "f34cf48f0a759e027052a69b007795f73b557e9d"
+        "commit": "80ac332708b8d98d286b2902ff6248c83092507d"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from f34cf48f to 80ac3327.

~~~
80ac3327 ath79-generic: (re)add support for Buffalo WZR-HP-G450H / WZR-450HP (#3588)
124b0acd Merge pull request #3587 from herbetom/main-updates
ff028f1a modules: update routing
7dab1cfa modules: update packages
b78b3e18 modules: update openwrt
a38c4a2f Merge pull request #3584 from freifunk-gluon/dependabot/github_actions/actions/labeler-6
31fe8b82 Merge pull request #3585 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.6.0
e0f77127 build(deps): bump docker/login-action from 3.5.0 to 3.6.0
2de3cb86 build(deps): bump actions/labeler from 5 to 6
4902bbd2 Merge pull request #3582 from ffac/update-openwrt-base
38a38996 modules: update routing
abfd4a96 modules: update packages
dd55d50a modules: update openwrt
e740dc8c ramips-mt76x8: add support for TP-Link Archer C50 v6 (#3568)
79910654 Merge pull request #3554 from freifunk-gluon/feat/statuspage-pubkey
21e37349 Merge pull request #3561 from freifunk-gluon/feat/add_xiaomi_ax3600
3b029f92 status-page: Emit VPN public key if enabled
73129414 mesh-vpn-core: Provide get_enabled_public_key()
cb20f286 qualcommax-ipq807x: Add Xiaomi AX3600
38b478c3 Merge pull request #3578 from freifunk-gluon/fix/remove-wireguard-pubkey-privacy
3b2b071f Merge pull request #3581 from freifunk-gluon/docs/gluon-state-check
a41b604c gluon-state-check: Provide documentation
2a9dfcb7 mesh-vpn: Remove `pubkey_privacy` setting for WireGuard
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>