### PR TITLE
build-info: update Gluon to 2025-10-28

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "80ac332708b8d98d286b2902ff6248c83092507d"
+        "commit": "8f28f72546eccf4b49c51fbea000976304e89342"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 80ac3327 to 8f28f725.

~~~
8f28f725 Merge pull request #3563 from ffac/refactor-wireless-triband
462e6a4d gluon-core: allow configuration of additional wireless settings using gluon_preserve
adc0867c gluon-core: set channel to auto if mesh is not possible
d7f2f1de gluon-core: implement detection of client_only_radio
442a6801 Merge pull request #3595 from achterin/feature/linksys_whw01_v1-updates
d6bf8a75 ipq40xx-generic: add Linksys VLP01 alias
ad7638b9 ipq40xx-generic: add Linksys WHW01
93968ca7 Merge pull request #3597 from freifunk-gluon/main-updates
8cfa65a9 modules: update packages
fe5f1594 modules: update openwrt
a34a3c7f Merge pull request #3596 from freifunk-gluon/main-issue-3425
7baa3c0b ath79-generic: additional reason for BROKEN device Archer C58
fcabea4f Merge pull request #3594 from freifunk-gluon/main-updates
418b4ffa modules: update packages
c809a926 modules: update openwrt
e742f024 gluon-web-wifi-config: adjust form for gluon roles
1ed6fba9 gluon-web-private-wifi: update to role based wireless section
b98109db gluon-private-wifi: add uci wireless config to gluon-private-wifi
58cd14b5 gluon-client-bridge: do not create wireless config if client role is disabled
97747da2 gluon-core: remove delete_ibss function
17f59562 gluon-core: add hop_penalty support for mesh interfaces and fix preserve_channels
8e9bc5c6 gluon-core: create wireless config from gluon wireless roles section
d654fd2a Merge pull request #3590 from freifunk-gluon/main-updates
25dcbc4a modules: update gluon
a3e76518 Merge pull request #2995 from T-X/pr-gluon-mesh-batman-adv-brmldproxy
96c7ba28 gluon-core: add initialization script of gluon wireless roles
4a029fa8 gluon-core: clean up band counting
e0d1d85c gluon-core: rename device_uses_11a to device_uses_band
f6ac72b8 gluon-mesh-batman-adv-brmldproxy: enable proxied querier with mc routers
80f9d191 gluon-mesh-batman-adv-brmldproxy: don't filter incoming MLD Reports
8ec599ca gluon-mesh-batman-adv-brmldproxy: avoid MLD report broadcasts
c6ee0f24 gluon-mesh-batman-adv-brmldproxy: add package
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>