### PR TITLE
build-info: update Gluon to 2025-11-10

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "8f28f72546eccf4b49c51fbea000976304e89342"
+        "commit": "8abad80deb907dd2900b8fddad5b4d49f687c1d0"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 8f28f725 to 8abad80d.

~~~
8abad80d Merge pull request #3609 from herbetom/main-updates
7f7bba6c modules: update packages
ab8dfbfd modules: update openwrt
423258a7 Merge pull request #3607 from achterin/feature/netgear_srr60_srs60
cd07df9d Merge pull request #3605 from FreifunkChemnitz/whw03v1
50da04f8 Merge pull request #3598 from ffac/fix_mt7622_renaming
f64e7e7f ipq40xx-generic: add NETGEAR SRR60/SRS60
e8fb6abd ipq40xx-generic: add support for linksys-whw03v1
b74fed5f Merge pull request #3606 from FreifunkChemnitz/mr8300
d04ea647 ipq40xx-generic: add linksys-mr8300
6ad79c9d Merge pull request #3603 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-3.4.1
6e878ea0 Merge pull request #3604 from freifunk-gluon/dependabot/github_actions/actions/upload-artifact-5
f5ba5863 build(deps): bump actions/upload-artifact from 4 to 5
6092c827 build(deps): bump korthout/backport-action from 3.3.0 to 3.4.1
99aeac40 Merge pull request #3418 from ffac/add_linksys_whw03_v2
484e265b patches: base-files: disable wiphy renaming
72c4c1a8 ipq40xx-generic: add support for linksys-whw03v2
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>