### PR TITLE
build-info: update Gluon to 2025-11-26

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "8abad80deb907dd2900b8fddad5b4d49f687c1d0"
+        "commit": "8f38662f44f5df69357ced93f166000716f018b3"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 8abad80d to 8f38662f.

~~~
8f38662f gluon-core: limit size of wireless buffers (#3620)
1a6aaa07 Merge pull request #3617 from neocturne/wan-dnsmasq-packetmark
7ee36707 Merge pull request #3612 from neocturne/module-order-migration
88468995 Merge pull request #3593 from neocturne/setup-mode-ssh-banner
1611210c Merge pull request #3622 from ffac/update-openwrt-main
1c7b87b2 modules: update packages
ae744380 modules: update openwrt
c23cd998 gluon-wan-dnsmasq: work around missing capabilities for libpacketmark
d386c0cb gluon-wan-dnsmasq: consistently quote variables
87ed0150 gluon-wan-dnsmasq: set jail name to gluon-wan-dnsmasq
0af1e351 net/l2tp: reset skb control buffer (#3614)
8d444052 gluon-core: add migration for Ethernet driver load order change
ddcd4371 Merge pull request #3431 from ffac/ng_wax206
b5d4bab3 Merge pull request #3600 from FGBxRamel/ax3000t
5baf5179 Merge pull request #3615 from achterin/feature/netgear_rbk50v1
fdccb9d5 Merge pull request #3611 from misanthropos/cudy-wr3000e
ad3f7237 ipq40xx-generic: add support for Netgear RBR50v1/RBS50v1
459330b5 mediatek-filogic: add cudy-wr3000e
38bc1b4c mediatek-mt7622: add support for netgear wax206
edda5a26 mediatek: Add support for Xiaomi AX3000T ubootmod
c893ab8d gluon-setup-mode: fix non-interactive dropbear sessions
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>