### PR TITLE
ci: build: remove more non-required packages

### DIFF
--- a/.github/free-runner-space.sh
+++ b/.github/free-runner-space.sh
@@ -13,10 +13,30 @@ sudo apt-get -y remove \
 	google-chrome-stable \
 	kubectl \
 	microsoft-edge-stable \
+	mono-complete \
+	powershell \
 	temurin-*-jdk
 
 # Remove Android SDK tools
 sudo rm -rf /usr/local/lib/android
+
+# Remove powershell
+sudo rm -rf /usr/local/share/powershell
+
+# Remove CodeQL cache
+sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+# remove dotnet
+sudo rm -rf /usr/share/dotnet
+
+# remove swift
+sudo rm -rf /usr/share/swift
+
+# remove ghcup (Haskell)
+sudo rm -rf /usr/local/.ghcup
+
+# remove no longer needed dependencies
+sudo apt-get autoremove
 
 echo "Disk space after cleanup"
 df -h


### PR DESCRIPTION
Without this mediatek-filogic doesn't seem happy.

This takes us from around 26 GB of free space to around 42 GB.

Fingers crossed that'll be enough for ages!