### PR TITLE
build-info: update Gluon to 2025-12-14

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "8f38662f44f5df69357ced93f166000716f018b3"
+        "commit": "dcd8475bcce51e301cf53ac45dd62115dc7a2b80"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 8f38662f to dcd8475b.

~~~
dcd8475b Merge pull request #3639 from ffac/update-main-openwrt
ef25b07f modules: update routing
d962fb47 modules: update packages
5aa9773c modules: update gluon
78d2a681 modules: update openwrt
7549dcb3 Merge pull request #3141 from herbetom/fix-readonly-ubiquiti-airmax
b0ef97da ath79-generic: (re)add support for Ubiquiti AirMax targets
8be1af4b Merge pull request #3625 from ffac/pubkey_privacy_wireguard
40cc833d Merge pull request #3632 from neocturne/site-version
ab782d89 Merge pull request #3631 from neocturne/supported-devices-fixes
c1d9a60c treewide: bump minimum CMake version (#3634)
93322f00 Merge pull request #3635 from blocktrron/netlink-flag-access
93d6970d gluon-status-page-mesh-batman-adv: wrap netlink flag value access
e60f4e93 gluon-mesh-batman-adv: wrap netlink flag value access
d3c3e4f4 gluon-core: use pubkey_privacy from provider
8a850819 docs: user/site, dev/build: mention annotated tags for `git describe`
f10b0a8b docs: user/site: improve toplevel description of site config
22ddb9c5 Revert " scripts: add --tags to git describe in getversion.sh to include lightweighted tags (#3310)"
a6c4e034 docs: user/supported_devices: move EAX11/EAX12/EAX15 to correct vendor
372f5c14 Merge pull request #3628 from freifunk-gluon/dependabot/github_actions/docker/metadata-action-5.10.0
f45c1c0c Merge pull request #3627 from freifunk-gluon/dependabot/github_actions/actions/checkout-6
7bcf3ffe Merge pull request #3630 from blocktrron/mptcp
c0f92599 generic: disable kernel MPTCP support
cbcbda74 mt7915: detect and purge stuck PLE queues (#3610)
4bbcbff5 contrib: fix removal of .NET (#3629)
f8ff0a21 wifi: mt76: mt76x02: wake queues after reconfig (#3621)
bf712cde build(deps): bump docker/metadata-action from 5.8.0 to 5.10.0
33151c87 build(deps): bump actions/checkout from 5 to 6
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>