### PR TITLE
build-info: update Gluon to 2025-12-24

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "dcd8475bcce51e301cf53ac45dd62115dc7a2b80"
+        "commit": "d80e1c990f429562a140ebafd43098e7b380f614"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from dcd8475b to d80e1c99.

~~~
d80e1c99 Merge pull request #3641 from herbetom/main-updates
00ebcbef modules: update packages
5bd5be2c modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>