### PR TITLE
build-info: update Gluon to 2026-01-08

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "5777810c92e56ef9ea0a57151c5f6d795a7e7642"
+        "commit": "efd3bbe01362c0f2e2d62b10ad13b4a76e53b27b"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 5777810c to efd3bbe0.

~~~
efd3bbe0 Merge pull request #3618 from neocturne/cellular-dns-v6
0dbfe1c7 gluon-core, gluon-wan-dnsmasq: delete unused cellular_6 iface
53cb89da gluon-core: split check-site.lua and introduce Lua Module: gluon.validation (#2927)
1190a2c2 Merge pull request #3652 from freifunk-gluon/dependabot/github_actions/korthout/backport-action-4.0.1
f0adc8a8 Merge pull request #3650 from freifunk-gluon/dependabot/github_actions/actions/upload-artifact-6
68d19389 build(deps): bump korthout/backport-action from 3.4.1 to 4.0.1
265d543a build(deps): bump actions/upload-artifact from 5 to 6
054a0022 gluon-core, gluon-wan-dnsmasq: also consider 'cellular' an uplink interface
4f371dd6 gluon-wan-dnsmasq: use interface.d interface list for hotplug script
eff36afb gluon-core: firewall: merge reject_input_on_wan() and add_cellular_wan()
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>