### PR TITLE
build-info: update Gluon to 2026-01-12

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "efd3bbe01362c0f2e2d62b10ad13b4a76e53b27b"
+        "commit": "390d4ba342741e7f758fcb0ddff4a9b453614a03"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from efd3bbe0 to 390d4ba3.

~~~
390d4ba3 Merge pull request #3654 from freifunk-gluon/status-page-infos
caabc4a4 Merge pull request #3662 from mbaumga/re3000
6cae5224 mediatek-filogic: add support for Cudy RE3000 v1
7c040c2d gluon-status-page: add ssid, htmode, base version and firmware target to overview
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>