### PR TITLE
build-info: update Gluon to 2026-01-23

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "390d4ba342741e7f758fcb0ddff4a9b453614a03"
+        "commit": "d36371f16fde557cfea4e14c618665b4058d8ea6"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from 390d4ba3 to d36371f1.

~~~
d36371f1 Merge pull request #3640 from ambassador86/cudy-ap1300outdoor
3678e8ef Merge pull request #3674 from ffac/update-openwrt-main
1ec8fff6 modules: update routing
ea424bbc modules: update packages
885b6fd4 modules: update openwrt
42592634 ramips-mt7621: Add Cudy WR3000h (v1.0) 2.5G WAN model (#3672)
955e155d ramips-mt7621: add support for Totolink X5000R (#3668)
b5e39c90 Merge pull request #3669 from ambassador86/cudy-wr3000s
b67f00b6 Merge pull request #3664 from freifunk-gluon/add_rocket_m2_xm
727a58b7 Merge pull request #3659 from freifunk-gluon/set_htmode_in_site
37f8067b mediatek-filogic: add support for Cudy WR3000S
b7414573 Merge pull request #3651 from freifunk-gluon/dependabot/pip/docs/sphinx-9.1.0
d0d88434 ath79-generic: re add support for ubiquiti-rocket-m-xm
d3ba9eb5 docs: rtd: sphinx >=9 is only available for python >= 3.12
91082013 build(deps): bump sphinx-rtd-theme from 3.0.2 to 3.1.0 in /docs
c634d832 gluon-core: add setting of htmode channel_width per radio
6a8178c6 ramips-mt7621: add support for Cudy AP1300 Outdoor v1
9e59df2a build(deps): bump sphinx from 8.2.3 to 9.1.0 in /docs
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>