### PR TITLE
.git-blame-ignore-revs: init

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# whitespace changes to site.conf
+84c2ddf33582ae4285c05ed18a0b2d4e8d40d8a1


### PR DESCRIPTION
This file allows us to ignore some commits during a blame.

Add the commit which reformated the site.conf file.

https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view