### PR TITLE
build-info: update Gluon to 2026-02-09

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "d36371f16fde557cfea4e14c618665b4058d8ea6"
+        "commit": "d7118443a94cb1495a22743a3f41d94f94ce4e86"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from d36371f1 to d7118443.

~~~
d7118443 Merge pull request #3685 from herbetom/x86_64-migration-with-usb
9521ef7a gluon-core: add common USB drivers to previous load order migration
2771ef3c mediatek-filogic: add device Mercusys MR90X v1
af46ccd0 Merge pull request #3675 from neocturne/sitedir-override
db79cba1 Merge pull request #3681 from freifunk-gluon/dependabot/github_actions/docker/login-action-3.7.0
49149900 build(deps): bump docker/login-action from 3.6.0 to 3.7.0
86242493 mediatek-mt7622: add support for Ubiquiti UniFi 6 LR v3 (#2982)
dbacb7fa Merge pull request #3663 from mbaumga/m3000
a8b0eb3b mediatek-filogic: add support for Cudy M3000 v1
cf2cf29e gluon-site: avoid variable name GLUON_SITEDIR
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>