### PR TITLE
build-info: update Gluon to 2026-02-10

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "main",
-        "commit": "d7118443a94cb1495a22743a3f41d94f94ce4e86"
+        "commit": "7213958360ac111f380094fd03cf5ac5b7a4a8e0"
     },
     "container": {
         "version": "main"


### PR DESCRIPTION
Update Gluon from d7118443 to 72139583.

~~~
72139583 modules: update to latest HEAD (#3690)
a25fc02f modules: update packages
0af29c5a modules: update openwrt
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>