### PR TITLE
CI: bump-gluon: use github-app token for PR creation

### DIFF
--- a/.github/actions/build-artifact/action.yml
+++ b/.github/actions/build-artifact/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - run: tar -cJf "$GITHUB_WORKSPACE/build-artifact-workdir/output.tar.xz" -C ${{ inputs.gluon-path }}/output images packages debug
       shell: bash
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.hardware-target }}
         path: build-artifact-workdir

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,9 +15,9 @@ jobs:
   backport:
     name: Backport Pull Request
     if: github.repository_owner == 'Freifunk-Rhein-Neckar' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create backport PRs
         uses: korthout/backport-action@v3.2.0
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,10 +18,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/create-github-app-token@v2
+        if: vars.GH_APP_ID != ''
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Create backport PRs
         uses: korthout/backport-action@v3.2.0
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
           pull_description: |-
             Automatic backport to `${target_branch}`, triggered by a label in #${pull_number}.
-   # yamllint enable rule:line-length
+          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+  # yamllint enable rule:line-length

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,10 +11,14 @@ permissions:
   pull-requests: write  # so it can create pull requests
 
 jobs:
-  # yamllint disable rule:line-length
   backport:
     name: Backport Pull Request
-    if: github.repository_owner == 'Freifunk-Rhein-Neckar' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    # yamllint disable rule:line-length
+    if: >
+      github.repository_owner == 'Freifunk-Rhein-Neckar' &&
+      github.event.pull_request.merged == true &&
+      (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    # yamllint enable rule:line-length
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -26,9 +30,11 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Create backport PRs
         uses: korthout/backport-action@v3.2.0
+        # yamllint disable rule:line-length
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
           pull_description: |-
             Automatic backport to `${target_branch}`, triggered by a label in #${pull_number}.
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-  # yamllint enable rule:line-length
+        id: create-backport-pr
+        # yamllint enable rule:line-length

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,10 @@ jobs:
       WORKFLOW_DISPATCH_REPOSITORY: ${{ github.event.inputs.repository }}
       WORKFLOW_DISPATCH_REFERENCE: ${{ github.event.inputs.reference }}
       WORKFLOW_DISPATCH_TARGETS: ${{ github.event.inputs.targets }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Determine build-meta
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone Europe/Berlin
@@ -82,7 +82,7 @@ jobs:
         run: bash .github/build-meta.sh
 
       - name: Create Artifact of build-meta
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-meta
           path: ${{ steps.build-metadata.outputs.build-meta-output }}
@@ -92,12 +92,12 @@ jobs:
     needs: build-meta
     outputs:
       targets: ${{ steps.get-targets.outputs.targets }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Get Gluon targets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ needs.build-meta.outputs.gluon-repository }}
           ref: ${{ needs.build-meta.outputs.gluon-commit }}
@@ -120,11 +120,11 @@ jobs:
 
   host-tools:
     needs: build-meta
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build host-tools
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           repository: ${{ needs.build-meta.outputs.gluon-repository }}
           ref: ${{ needs.build-meta.outputs.gluon-commit }}
@@ -144,7 +144,7 @@ jobs:
 
       - name: Restore Cache
         id: restore-cache-tools
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: gluon-gha-data/gluon/openwrt
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}
@@ -174,7 +174,7 @@ jobs:
         if: >
           github.ref_type != 'tag' &&
           steps.restore-cache-tools.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: gluon-gha-data/gluon/openwrt
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}
@@ -188,7 +188,7 @@ jobs:
           --posix -C "gluon-gha-data/gluon" openwrt
 
       - name: Archive build output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openwrt
           path: "gluon-gha-data/openwrt"
@@ -201,16 +201,16 @@ jobs:
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.targets.outputs.targets) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: >
       needs.targets.outputs.targets != '[]'
     permissions:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ needs.build-meta.outputs.gluon-repository }}
           ref: ${{ needs.build-meta.outputs.gluon-commit }}
@@ -242,7 +242,7 @@ jobs:
         run: bash .github/free-runner-space.sh
 
       - name: Download prepared OpenWrt
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: openwrt
           path: "gluon-gha-data/openwrt"
@@ -285,7 +285,7 @@ jobs:
 
       - name: Attest Image Build Provenance
         if: ${{ needs.build-meta.outputs.create-release != '0' }}
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: |
             "gluon-gha-data/gluon/output/images/sysupgrade/*"
@@ -295,7 +295,7 @@ jobs:
   # target job for required status check of build success
   build-complete:
     name: All Targets Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [build, build-meta, targets]
     if: ${{ !cancelled() }}
     steps:
@@ -309,12 +309,12 @@ jobs:
 
   manifest:
     needs: [build, build-meta, targets]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: >
       needs.targets.outputs.targets != '[]' &&
       github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone Europe/Berlin
@@ -322,19 +322,19 @@ jobs:
       - name: Show current Timezone settings
         run: timedatectl status
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: "gluon-gha-data/gluon-output"
 
       - name: Clone Gluon
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ needs.build-meta.outputs.gluon-repository }}
           ref: ${{ needs.build-meta.outputs.gluon-commit }}
           path: 'gluon-gha-data/gluon'
 
       - name: Download prepared OpenWrt
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: openwrt
           path: "gluon-gha-data/openwrt"
@@ -474,7 +474,7 @@ jobs:
           -C gluon-gha-data/gluon/output/images/sysupgrade -T -
 
       - name: Archive output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: manifest-signed
           path: gluon-gha-data/artifact-out
@@ -482,13 +482,13 @@ jobs:
 
   deploy:
     needs: [build, build-meta, targets, manifest]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: >
       needs.targets.outputs.targets != '[]' &&
       needs.build-meta.outputs.deploy != '0' &&
       github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone Europe/Berlin
@@ -496,7 +496,7 @@ jobs:
       - name: Show current Timezone settings
         run: timedatectl status
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: "gluon-gha-data/artifact-download"
 
@@ -544,7 +544,7 @@ jobs:
 
   link-release:
     needs: [build, build-meta, targets, manifest, deploy]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: >
       needs.targets.outputs.targets != '[]' &&
       needs.build-meta.outputs.deploy != '0' &&
@@ -575,7 +575,7 @@ jobs:
 
   create-release:
     needs: [build, build-meta, targets, manifest]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: >
       needs.targets.outputs.targets != '[]' &&
       needs.build-meta.outputs.create-release != '0' &&
@@ -585,7 +585,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone Europe/Berlin
@@ -593,7 +593,7 @@ jobs:
       - name: Show current Timezone settings
         run: timedatectl status
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: "gluon-gha-data/artifact-download"
 
@@ -628,7 +628,7 @@ jobs:
           gluon-gha-data/release-notes.md
 
       - name: Attest Release Artifact Build Provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: |
             gluon-gha-data/release-artifacts/*

--- a/.github/workflows/bump-gluon.yml
+++ b/.github/workflows/bump-gluon.yml
@@ -90,6 +90,13 @@ jobs:
           branch: bump-gluon-${{ github.event.inputs.site-branch }}-${{ steps.head-hash.outputs.short-hash }}
           create_branch: true
 
+      - uses: actions/create-github-app-token@v2
+        if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash && github.event.inputs.skip-pull-request == 'false' && vars.GH_APP_ID != ''
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Create pull request
         if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash && github.event.inputs.skip-pull-request == 'false'
         run: >-
@@ -98,7 +105,7 @@ jobs:
           -H bump-gluon-${{ github.event.inputs.site-branch }}-${{ steps.head-hash.outputs.short-hash }}
           --fill
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Emit PR creation message
         if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash && github.event.inputs.skip-pull-request == 'true'

--- a/.github/workflows/bump-gluon.yml
+++ b/.github/workflows/bump-gluon.yml
@@ -18,7 +18,7 @@ on:
         description: "Skip pull request creation"
         type: boolean
         required: true
-        default: true
+        default: false
 
 jobs:
   update-gluon:

--- a/.github/workflows/bump-gluon.yml
+++ b/.github/workflows/bump-gluon.yml
@@ -32,7 +32,7 @@ jobs:
       COMMIT_EMAIL: info@freifunk-rhein-neckar.de
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.site-branch }}
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Commit and push changes
         if: steps.head-hash.outputs.hash != steps.build-info-hash.outputs.hash
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: ${{ steps.commit-message.outputs.msg }}
           commit_options: '--no-verify --signoff'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,12 @@ on: [push, pull_request]
 jobs:
   lint-yaml:
     name: "YAML"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       YAML_FILES: |
         .github/workflows/*.yml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y yamllint
       - name: Validate YAML Files
@@ -20,13 +20,13 @@ jobs:
 
   shellcheck:
     name: "Shell Scripts"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SHELL_FILES: >-
         contrib/*.sh
         .github/*.sh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Validate Shell Scripts
@@ -34,12 +34,12 @@ jobs:
 
   image-customization:
     name: "Image-Customization"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       LUA_FILES: >-
         image-customization.lua
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Dependencies
         run: sudo apt-get -y update && sudo apt-get -y install lua-check
       - name: Lint Image-Customization
@@ -47,11 +47,11 @@ jobs:
 
   json:
     name: "JSON"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       BUILD_INFO: ${{ github.workspace }}/.github/build-info.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Validator
         run: sudo apt-get update && sudo apt-get install -y python3-demjson
       - name: Run validation


### PR DESCRIPTION
This enables workflows to run automatically.

Needs the following Variable set: GH_APP_ID

And the following secret: GH_APP_PRIVATE_KEY

Borrowed the list of necessary permissions for the GitHub App from here:

https://github.com/peter-evans/create-pull-request/blob/98357b18bf14b5342f975ff684046ec3b2a07725/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens

While at it bump a bunch of actions and runner images.