### PR TITLE
CI: build: add support for other build image url

### DIFF
--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -56,6 +56,7 @@ else
 fi
 
 # Get Container version information
+CONTAINER_IMAGE="$(jq -r '.container?.image // ""' "$SCRIPT_DIR/build-info.json")"
 CONTAINER_VERSION="$(jq -r -e .container.version "$SCRIPT_DIR/build-info.json")"
 
 # Get Default Release version from site.mk
@@ -183,27 +184,35 @@ RELEASE_VERSION="${RELEASE_VERSION:-$DEFAULT_RELEASE_VERSION}"
 BUILD_META_TMP_DIR="$(mktemp -d)"
 BUILD_META_OUTPUT="$BUILD_META_TMP_DIR/build-meta.txt"
 
-# shellcheck disable=SC2129
-# Not the nicest way to do this, but it works.
-echo "build-meta-output=$BUILD_META_TMP_DIR" >> "$BUILD_META_OUTPUT"
-echo "container-version=$CONTAINER_VERSION" >> "$BUILD_META_OUTPUT"
-echo "gluon-repository=$GLUON_REPOSITORY" >> "$BUILD_META_OUTPUT"
-echo "gluon-commit=$GLUON_COMMIT" >> "$BUILD_META_OUTPUT"
-echo "site-version=$SITE_VERSION" >> "$BUILD_META_OUTPUT"
-echo "release-version=$RELEASE_VERSION" >> "$BUILD_META_OUTPUT"
-echo "autoupdater-enabled=$AUTOUPDATER_ENABLED" >> "$BUILD_META_OUTPUT"
-echo "autoupdater-branch=$AUTOUPDATER_BRANCH" >> "$BUILD_META_OUTPUT"
-echo "broken=$BROKEN" >> "$BUILD_META_OUTPUT"
-echo "manifest-stable=$MANIFEST_STABLE" >> "$BUILD_META_OUTPUT"
-echo "manifest-beta=$MANIFEST_BETA" >> "$BUILD_META_OUTPUT"
-echo "manifest-experimental=$MANIFEST_EXPERIMENTAL" >> "$BUILD_META_OUTPUT"
-echo "manifest-nightly=$MANIFEST_NIGHTLY" >> "$BUILD_META_OUTPUT"
-echo "sign-manifest=$SIGN_MANIFEST" >> "$BUILD_META_OUTPUT"
-echo "deploy=$DEPLOY" >> "$BUILD_META_OUTPUT"
-echo "link-release=$LINK_RELEASE" >> "$BUILD_META_OUTPUT"
-echo "create-release=$CREATE_RELEASE" >> "$BUILD_META_OUTPUT"
-echo "pre-release=$PRE_RELEASE" >> "$BUILD_META_OUTPUT"
-echo "target-whitelist=$TARGET_WHITELIST" >> "$BUILD_META_OUTPUT"
+write_output() {
+  local key="$1"
+  local value="$2"
+
+  if [ -n "$value" ]; then
+    echo "$key=$value" >> "$BUILD_META_OUTPUT"
+  fi
+}
+
+write_output "build-meta-output" "$BUILD_META_TMP_DIR"
+write_output "container-image" "$CONTAINER_IMAGE"
+write_output "container-version" "$CONTAINER_VERSION"
+write_output "gluon-repository" "$GLUON_REPOSITORY"
+write_output "gluon-commit" "$GLUON_COMMIT"
+write_output "site-version" "$SITE_VERSION"
+write_output "release-version" "$RELEASE_VERSION"
+write_output "autoupdater-enabled" "$AUTOUPDATER_ENABLED"
+write_output "autoupdater-branch" "$AUTOUPDATER_BRANCH"
+write_output "broken" "$BROKEN"
+write_output "manifest-stable" "$MANIFEST_STABLE"
+write_output "manifest-beta" "$MANIFEST_BETA"
+write_output "manifest-experimental" "$MANIFEST_EXPERIMENTAL"
+write_output "manifest-nightly" "$MANIFEST_NIGHTLY"
+write_output "sign-manifest" "$SIGN_MANIFEST"
+write_output "deploy" "$DEPLOY"
+write_output "link-release" "$LINK_RELEASE"
+write_output "create-release" "$CREATE_RELEASE"
+write_output "pre-release" "$PRE_RELEASE"
+write_output "target-whitelist" "$TARGET_WHITELIST"
 
 # Copy over to GITHUB_OUTPUT
 cat "$BUILD_META_OUTPUT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}
 
       - name: Update Gluon
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: steps.restore-cache-tools.outputs.cache-hit != 'true'
         id: update-gluon
         with:
@@ -160,7 +160,7 @@ jobs:
           site-path: "."
 
       - name: Build host-tools
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: steps.restore-cache-tools.outputs.cache-hit != 'true'
         id: build-host-tools
         with:
@@ -252,7 +252,7 @@ jobs:
           tar xf gluon-gha-data/openwrt/openwrt.tar.xz -C gluon-gha-data/gluon
 
       - name: Gluon Update
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         id: update-gluon
         with:
           container-version: ${{ needs.build-meta.outputs.container-version }}
@@ -262,7 +262,7 @@ jobs:
 
       - name: Build
         # yamllint disable-line rule:line-length
-        uses: freifunk-gluon/action-build@3a48a4d0db08ff393e08ec3074f1b218ee5ac54b
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         id: build-gluon
         with:
           container-version: ${{ needs.build-meta.outputs.container-version }}
@@ -351,7 +351,7 @@ jobs:
           targets: ${{ needs.targets.outputs.targets }}
 
       - name: Gluon Update
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         id: update-gluon
         with:
           container-version: ${{ needs.build-meta.outputs.container-version }}
@@ -359,7 +359,7 @@ jobs:
           make-target: update
 
       - name: Manifest (Stable)
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-stable != '0' }}
         with:
           container-version: ${{ needs.build-meta.outputs.container-version }}
@@ -370,7 +370,7 @@ jobs:
           priority: 1
 
       - name: Manifest (Beta)
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-beta != '0' }}
         with:
           container-version: >-
@@ -383,7 +383,7 @@ jobs:
           priority: 1
 
       - name: Manifest (Experimental)
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-experimental != '0' }}
         with:
           container-version: >-
@@ -396,7 +396,7 @@ jobs:
           priority: 1
 
       - name: Manifest (Nightly)
-        uses: freifunk-gluon/action-build@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-nightly != '0' }}
         with:
           container-version: ${{ needs.build-meta.outputs.container-version }}
@@ -408,7 +408,7 @@ jobs:
           broken: ${{ needs.build-meta.outputs.broken }}
 
       - name: Sign manifest (Stable)
-        uses: freifunk-gluon/action-sign@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-sign@v2
         if: >
           needs.build-meta.outputs.manifest-stable != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'
@@ -421,7 +421,7 @@ jobs:
           write-signature: "true"
 
       - name: Sign manifest (Beta)
-        uses: freifunk-gluon/action-sign@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-sign@v2
         if: >
           needs.build-meta.outputs.manifest-beta != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'
@@ -434,7 +434,7 @@ jobs:
           write-signature: "true"
 
       - name: Sign manifest (Experimental)
-        uses: freifunk-gluon/action-sign@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-sign@v2
         if: >
           needs.build-meta.outputs.manifest-experimental != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'
@@ -448,7 +448,7 @@ jobs:
 
 
       - name: Sign manifest (Nightly)
-        uses: freifunk-gluon/action-sign@v1
+        uses: Freifunk-Rhein-Neckar/gluon-action-sign@v2
         if: >
           needs.build-meta.outputs.manifest-nightly != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ concurrency:
 jobs:
   build-meta:
     outputs:
+      container-image: >-
+        ${{ steps.build-metadata.outputs.container-image }}
       container-version: >-
         ${{ steps.build-metadata.outputs.container-version }}
       release-version: >-
@@ -154,6 +156,7 @@ jobs:
         if: steps.restore-cache-tools.outputs.cache-hit != 'true'
         id: update-gluon
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           make-target: update
@@ -164,6 +167,7 @@ jobs:
         if: steps.restore-cache-tools.outputs.cache-hit != 'true'
         id: build-host-tools
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           make-target: openwrt/staging_dir/hostpkg/bin/lua
@@ -255,6 +259,7 @@ jobs:
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         id: update-gluon
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           hardware-target: ath79-generic
@@ -265,6 +270,7 @@ jobs:
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         id: build-gluon
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           hardware-target: ${{ matrix.target }}
@@ -354,6 +360,7 @@ jobs:
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         id: update-gluon
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           make-target: update
@@ -362,6 +369,7 @@ jobs:
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-stable != '0' }}
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           make-target: manifest
@@ -373,6 +381,7 @@ jobs:
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-beta != '0' }}
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: >-
             ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
@@ -386,6 +395,7 @@ jobs:
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-experimental != '0' }}
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: >-
             ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
@@ -399,6 +409,7 @@ jobs:
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
         if: ${{ needs.build-meta.outputs.manifest-nightly != '0' }}
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           make-target: manifest
@@ -413,6 +424,7 @@ jobs:
           needs.build-meta.outputs.manifest-stable != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           manifest: >-
@@ -426,6 +438,7 @@ jobs:
           needs.build-meta.outputs.manifest-beta != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           manifest: >-
@@ -439,6 +452,7 @@ jobs:
           needs.build-meta.outputs.manifest-experimental != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           manifest: >-
@@ -453,6 +467,7 @@ jobs:
           needs.build-meta.outputs.manifest-nightly != '0' &&
           needs.build-meta.outputs.sign-manifest != '0'
         with:
+          container-image: ${{ needs.build-meta.outputs.container-image }}
           container-version: ${{ needs.build-meta.outputs.container-version }}
           gluon-path: "gluon-gha-data/gluon"
           manifest: >-


### PR DESCRIPTION
This is useful in cases where no official image exists or for testing.