### PR TITLE
CI: don't zip the assets

### DIFF
--- a/.github/actions/build-artifact/action.yml
+++ b/.github/actions/build-artifact/action.yml
@@ -12,12 +12,12 @@ runs:
   steps:
     - run: mkdir -p "$GITHUB_WORKSPACE/build-artifact-workdir"
       shell: bash
-    - run: tar -cJf "$GITHUB_WORKSPACE/build-artifact-workdir/output.tar.xz" -C ${{ inputs.gluon-path }}/output images packages debug
+    - run: tar -cJf "$GITHUB_WORKSPACE/build-artifact-workdir/${{ inputs.hardware-target }}.tar.xz" -C ${{ inputs.gluon-path }}/output images packages debug
       shell: bash
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       with:
-        name: ${{ inputs.hardware-target }}
         path: build-artifact-workdir
         compression-level: 0
+        archive: false
     - run: rm -rf "$GITHUB_WORKSPACE/build-artifact-workdir"
       shell: bash

--- a/.github/actions/build-combine/combine-build.sh
+++ b/.github/actions/build-combine/combine-build.sh
@@ -22,20 +22,22 @@ ARTIFACT_OUT_DIR="$RUNNER_TEMP/output"
 EXTRACT_TEMP_DIR="$RUNNER_TEMP/extract"
 
 mkdir -p "$ARTIFACT_OUT_DIR"
-for artifact_target in $ARTIFACT_NAMES ; do
+for artifact_target_archive in $ARTIFACT_NAMES ; do
+	# remove .tar.xz suffix to get target name
+	artifact_target=${artifact_target_archive%".tar.xz"}
 	# Check if artifact in list. Only delete otherwise.
 	if [ -n "$TARGET_LIST" ] && [[ "$TARGET_LIST" =~ "$artifact_target" ]]; then
 		echo "Combining ${artifact_target}"
 
 		EXTRACT_TEMP_DIR_TARGET="${EXTRACT_TEMP_DIR}/${artifact_target}"
-		ARTIFACT_SRC_DIR_TARGET="${ACTION_ARTIFACT_DIR}/${artifact_target}"
+		ARTIFACT_SRC_DIR_TARGET="${ACTION_ARTIFACT_DIR}/${artifact_target_archive}"
 
 		if [[ "$ACTION_KEEP_PACKED" != "1" ]]; then
 			# Create Temporary extraction directory
 			mkdir -p "${EXTRACT_TEMP_DIR_TARGET}"
 
 			# Unpack archive
-			tar xf "${ARTIFACT_SRC_DIR_TARGET}/output.tar.xz" -C "${EXTRACT_TEMP_DIR_TARGET}"
+			tar xf "${ARTIFACT_SRC_DIR_TARGET}/${artifact_target_archive}" -C "${EXTRACT_TEMP_DIR_TARGET}"
 
 			# Combine targets
 			rsync -a ${EXTRACT_TEMP_DIR_TARGET}/* "$ARTIFACT_OUT_DIR"
@@ -44,7 +46,7 @@ for artifact_target in $ARTIFACT_NAMES ; do
 			rm -rf "${EXTRACT_TEMP_DIR_TARGET}"
 		else
 			# Copy and rename archive
-			cp "${ARTIFACT_SRC_DIR_TARGET}/output.tar.xz" "${ARTIFACT_OUT_DIR}/${artifact_target}.tar.xz"
+			cp "${ARTIFACT_SRC_DIR_TARGET}/${artifact_target_archive}" "${ARTIFACT_OUT_DIR}/${artifact_target}.tar.xz"
 		fi
 
 		# Delete artifacts if enabled

--- a/.github/build-meta.sh
+++ b/.github/build-meta.sh
@@ -3,7 +3,6 @@
 set -euxo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
-UPSTREAM_REPO_NAME="freifunk-rhein-neckar/site-ffrn"
 
 # Get Git short hash for repo at $SCRIPT_DIR
 GIT_SHORT_HASH="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
@@ -161,19 +160,19 @@ if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
 	SIGN_MANIFEST="0"
 fi
 
-# Signing should only happen when pushed to the upstream repository.
+# Signing should only happen when explicitly enabled via the GHA_FFRN_BUILD_SIGN_ENABLED=1 variable
 # Skip this step for the pipeline to succeed but inform the user.
-if [ "${GITHUB_REPOSITORY,,}" != "${UPSTREAM_REPO_NAME,,}" ] && [ "$SIGN_MANIFEST" != "0" ]; then
+if [ "${GHA_FFRN_BUILD_SIGN_ENABLED:-0}" != "1" ] && [ "$SIGN_MANIFEST" != "0" ]; then
 	SIGN_MANIFEST="0"
 
-	echo "::warning::Skip manifest signature due to action running in fork."
+	echo "::warning::Skip manifest signature because GHA_FFRN_BUILD_SIGN_ENABLED is not set to 1."
 fi
 
-# We should neither deploy in a fork, as the workflow is hard-coding our firmware-server
-if [ "${GITHUB_REPOSITORY,,}" != "${UPSTREAM_REPO_NAME,,}" ] && [ "$DEPLOY" != "0" ]; then
+# Deployment should only happen when explicitly enabled via the GHA_FFRN_BUILD_DEPLOY_ENABLED=1 variable
+if [ "${GHA_FFRN_BUILD_DEPLOY_ENABLED:-0}" != "1" ] && [ "$DEPLOY" != "0" ]; then
 	DEPLOY="0"
 
-	echo "::warning::Skip deployment due to action running in fork."
+	echo "::warning::Skip deployment because GHA_FFRN_BUILD_DEPLOY_ENABLED is not set to 1."
 fi
 
 # Determine Version to use

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,3 +17,14 @@ Private ECDSA key for signing the manifest for a given `branch`.
 ## check-build-info
 
 Validate the `build-info.json` is valid JSON.
+
+
+### Variables
+
+#### GHA_FFRN_BUILD_SIGN_ENABLED
+
+Set to 1 to enable signing of manifests. Default is to skip signing so that it won't cause problems in forks.
+
+#### GHA_FFRN_BUILD_DEPLOY_ENABLED
+
+Set to 1 to enable deployment of firmware. Default is to skip deployment so that it won't cause problems in forks.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
       WORKFLOW_DISPATCH_REPOSITORY: ${{ github.event.inputs.repository }}
       WORKFLOW_DISPATCH_REFERENCE: ${{ github.event.inputs.reference }}
       WORKFLOW_DISPATCH_TARGETS: ${{ github.event.inputs.targets }}
+      GHA_FFRN_BUILD_DEPLOY_ENABLED: ${{ vars.GHA_FFRN_BUILD_DEPLOY_ENABLED }}
+      GHA_FFRN_BUILD_SIGN_ENABLED: ${{ vars.GHA_FFRN_BUILD_SIGN_ENABLED }}
     runs-on: ubuntu-24.04
     name: Determine build-meta
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v6
 
@@ -291,7 +292,7 @@ jobs:
 
       - name: Attest Image Build Provenance
         if: ${{ needs.build-meta.outputs.create-release != '0' }}
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: |
             "gluon-gha-data/gluon/output/images/sysupgrade/*"
@@ -599,6 +600,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v6
 
@@ -643,7 +645,7 @@ jobs:
           gluon-gha-data/release-notes.md
 
       - name: Attest Release Artifact Build Provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: |
             gluon-gha-data/release-artifacts/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,10 @@ jobs:
         run: bash .github/build-meta.sh
 
       - name: Create Artifact of build-meta
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: build-meta
           path: ${{ steps.build-metadata.outputs.build-meta-output }}
+          archive: false
 
 
   targets:
@@ -186,20 +186,17 @@ jobs:
           path: gluon-gha-data/gluon/openwrt
           key: openwrt-${{ steps.cache-key.outputs.cache-key }}
 
-      - name: Create Artifact output directory
-        run: mkdir gluon-gha-data/openwrt
-
       - name: Pack Output
         run: >
-          tar cJf "gluon-gha-data/openwrt/openwrt.tar.xz"
+          tar cJf "gluon-gha-data/openwrt.tar.xz"
           --posix -C "gluon-gha-data/gluon" openwrt
 
       - name: Archive build output
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: openwrt
-          path: "gluon-gha-data/openwrt"
+          path: "gluon-gha-data/openwrt.tar.xz"
           compression-level: 0
+          archive: false
 
 
   build:
@@ -249,14 +246,14 @@ jobs:
         run: bash .github/free-runner-space.sh
 
       - name: Download prepared OpenWrt
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: openwrt
-          path: "gluon-gha-data/openwrt"
+          name: openwrt.tar.xz
+          path: "gluon-gha-data/"
 
       - name: Restore OpenWrt
         run: >
-          tar xf gluon-gha-data/openwrt/openwrt.tar.xz -C gluon-gha-data/gluon
+          tar xf gluon-gha-data/openwrt.tar.xz -C gluon-gha-data/gluon
 
       - name: Gluon Update
         uses: Freifunk-Rhein-Neckar/gluon-action-build@v2
@@ -331,7 +328,7 @@ jobs:
       - name: Show current Timezone settings
         run: timedatectl status
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: "gluon-gha-data/gluon-output"
 
@@ -343,14 +340,14 @@ jobs:
           path: 'gluon-gha-data/gluon'
 
       - name: Download prepared OpenWrt
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: openwrt
-          path: "gluon-gha-data/openwrt"
+          name: openwrt.tar.xz
+          path: "gluon-gha-data/"
 
       - name: Restore OpenWrt
         run: |
-          tar xf gluon-gha-data/openwrt/openwrt.tar.xz -C gluon-gha-data/gluon
+          tar xf gluon-gha-data/openwrt.tar.xz -C gluon-gha-data/gluon
 
       - name: Combine Build output
         uses: ./.github/actions/build-combine
@@ -492,10 +489,10 @@ jobs:
           -C gluon-gha-data/gluon/output/images/sysupgrade -T -
 
       - name: Archive output
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: manifest-signed
           path: gluon-gha-data/artifact-out
+          archive: false
 
 
   deploy:
@@ -514,7 +511,7 @@ jobs:
       - name: Show current Timezone settings
         run: timedatectl status
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: "gluon-gha-data/artifact-download"
 
@@ -531,7 +528,7 @@ jobs:
       - name: Extract Manifest
         run: >
           tar xf
-          gluon-gha-data/artifact-download/manifest-signed/manifest.tar.xz
+          gluon-gha-data/artifact-download/manifest.tar.xz/manifest.tar.xz
           -C gluon-gha-data/gluon-output/output/images/sysupgrade
 
       - name: Save SSH Key for deployment
@@ -611,7 +608,7 @@ jobs:
       - name: Show current Timezone settings
         run: timedatectl status
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: "gluon-gha-data/artifact-download"
 
@@ -628,12 +625,12 @@ jobs:
 
       - name: Move manifest archive
         run: >-
-          mv gluon-gha-data/artifact-download/manifest-signed/manifest.tar.xz
+          mv gluon-gha-data/artifact-download/manifest.tar.xz/manifest.tar.xz
           gluon-gha-data/release-artifacts/manifest.tar.xz
 
-      - name: Move manifest archive
+      - name: Move build-meta
         run: >-
-          mv gluon-gha-data/artifact-download/build-meta/build-meta.txt
+          mv gluon-gha-data/artifact-download/build-meta.txt/build-meta.txt
           gluon-gha-data/release-artifacts/build-meta.txt
 
       - name: Show File sizes


### PR DESCRIPTION
This takes advantage of GitHubs new functionally of not having to zip single files during artifact upload. This makes handling them easier.

https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/

While at it there were also some other more minor changes like the change of the deploy and signing condition. 
Previously the org+repo name was hardcoded. Now it's a Variable which can be set within GitHub. Default is (also if the Variables is absent) to skip Deployment and Signing. This makes testing in forks easier while keeping the idea that actions should succeed by default in Forks.