### PR TITLE
ci: build: don't trigger build for certain branch patterns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ name: "Build Gluon images"
 on:
   pull_request:
   push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'bump-gluon-*'
+      - 'backport-[0-9]+-to-*'
+      - 'pr-**'
   workflow_dispatch:
     inputs:
       repository:


### PR DESCRIPTION
This maninly attempts to prevent situations where the CI is run both for the pushed branch and for the PR.

It includes an pattern for dependabot branches, bump branches, backport branches as well as the pr-* pattern for branches where oneself will know that a PR is opened immediately.

Not all of those bot based actions currently trigger an workflow run but should there be an manual push to that branch it could still be relevant.

This is a deny list (and not an allow list) approach because it still makes sense that it's possible to just push a branch and see wheter it works.