### PR TITLE
site.conf: enable the OWE Transition Modes

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -51,7 +51,7 @@
         ap = {
             ssid = 'freifunk-rhein-neckar.de',
             owe_ssid = "owe.freifunk-rhein-neckar.de",
-            owe_transition_mode = false,
+            owe_transition_mode = true,
         },
         mesh = {
             id = 'ffrn-mesh',
@@ -65,7 +65,7 @@
         ap = {
             ssid = 'freifunk-rhein-neckar.de',
             owe_ssid = "owe.freifunk-rhein-neckar.de",
-            owe_transition_mode = false,
+            owe_transition_mode = true,
         },
         mesh = {
             id = 'ffrn-mesh',


### PR DESCRIPTION
In Darmstadt 75 to 90% clients are now using OWE.

And even Ubiquiti has now support for it.

My Pixel 8a with GrapheneOS also doesn't care and will connect either way if APs will send out our "freifunk-rhein-neckar.de" SSID but don't support OWE. Not sure if other devices behave differently. But all our currently supported devices are able to do the transition mode so even if some devices won't automatically connect to still running nodes with deprecated firmware and that same SSID it shouldn't be that dramatic.

Further info (in German) and consideration can be found in this thread: https://forum.freifunk.net/t/owe-standardmaessig-fuer-freifunk-aps-aktivieren/24045?u=tomh