### PR TITLE
CI: add merge_group trigger for merge queue evaluation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ name: "Build Gluon images"
 # yamllint disable-line rule:truthy
 on:
   pull_request:
+  merge_group:
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@
 name: "Lint"
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 jobs:
   lint-yaml:


### PR DESCRIPTION
These are the required workflow checks which need to run for a merge.

Add the trigger so that if there is a merge queue these run.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#how-merge-queues-work

It is not yet clear if merge queues really would be a good fit. But testing it seems like a good way to find that out :)