### PR TITLE
ci: build: trigger build for all tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - 'bump-gluon-*'
       - 'backport-[0-9]+-to-*'
       - 'pr-**'
+    tags:
+      - '**'
   workflow_dispatch:
     inputs:
       repository:


### PR DESCRIPTION
Without this builds aren't triggered for tags.

Fixes f93878c5d17abf18b759317d81d5475a5235c92c (#106)